### PR TITLE
feat: musicId를 사용하여 가사 API 호출 개선

### DIFF
--- a/src/pages/search/SearchAll.tsx
+++ b/src/pages/search/SearchAll.tsx
@@ -2,6 +2,10 @@
 import { useEffect, useMemo, useRef, useState, useCallback } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { MdOutlineNavigateNext, MdPlayArrow } from "react-icons/md";
+import axios from "axios";
+
+import { usePlayer } from "../../player/PlayerContext";
+import type { PlayerTrack } from "../../player/PlayerContext";
 
 // ✅ MyPlaylistPage 디자인 참고용 스크롤러(디자인만)
 type HorizontalScrollerProps = {
@@ -134,6 +138,7 @@ type ArtistDetail = {
 // API 응답 타입
 type ApiSearchResult = {
   itunes_id: number;
+  music_id?: number; // 실제 재생에 사용할 음악 ID
   music_name: string;
   artist_name: string;
   artist_id: number | null;
@@ -219,6 +224,7 @@ function SectionShell({
 export default function SearchHome() {
   const navigate = useNavigate();
   const [sp] = useSearchParams();
+  const { playTracks } = usePlayer();
 
   const q = (sp.get("q") ?? "").trim();
   const search = q ? `?q=${encodeURIComponent(q)}` : "";
@@ -231,6 +237,7 @@ export default function SearchHome() {
   const [apiAlbums, setApiAlbums] = useState<ArtistAlbum[]>([]);
   const [loading, setLoading] = useState(false);
   const [artistDetails, setArtistDetails] = useState<Record<number, ArtistDetail>>({});
+  const [searchResults, setSearchResults] = useState<ApiSearchResult[]>([]); // 검색 결과 원본 데이터 저장
 
   // 아티스트 상세 정보 가져오기 (이미지 포함)
   const fetchArtistDetails = useCallback(
@@ -368,6 +375,7 @@ export default function SearchHome() {
       setApiSongs([]);
       setApiArtists([]);
       setApiAlbums([]);
+      setSearchResults([]);
       return;
     }
 
@@ -393,6 +401,9 @@ export default function SearchHome() {
         }
 
         const data: ApiSearchResponse = await res.json();
+        
+        // 검색 결과 원본 데이터 저장
+        setSearchResults(data.results);
 
         // 곡 정보 변환
         const convertedSongs: Song[] = data.results.map((r) => ({
@@ -693,32 +704,230 @@ export default function SearchHome() {
                         </div>
                       </div>
 
-                      {/* ▶ 재생 버튼 (곡일 때만 표시) */}
-                      {!isArtist && (
-                        <button
-                          type="button"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            // TODO: 여기서 실제 재생 연결
-                          }}
-                          className="
-                            absolute right-0 bottom-4
-                            -translate-x-4 -translate-y-4
-                            w-12 h-12 rounded-full
-                            bg-[#AFDEE2] text-[#1d1d1d]
-                            grid place-items-center
-                            shadow-lg
-                            hover:bg-[#87B2B6] transition
+                      {/* ▶ 재생 버튼 */}
+                      <button
+                        type="button"
+                        onClick={async (e) => {
+                          e.stopPropagation();
+                          
+                          if (isArtist && artistData) {
+                            // 검색 결과에서 해당 아티스트의 모든 곡 찾기
+                            try {
+                              const artistIdNum = Number(artistData.id);
+                              if (isNaN(artistIdNum)) return;
+                              
+                              // 검색 결과에서 해당 아티스트의 곡들 필터링
+                              const artistSongs = searchResults.filter(
+                                (r) => r.artist_id === artistIdNum
+                              );
+                              
+                              if (artistSongs.length === 0) {
+                                console.warn(`[SearchAll] 검색 결과에서 아티스트 ${artistData.name}의 곡을 찾을 수 없습니다.`);
+                                return;
+                              }
+                              
+                              // PlayerTrack으로 변환
+                              const playerTracks: PlayerTrack[] = await Promise.all(
+                                artistSongs.map(async (r) => {
+                                  let audioUrl = r.audio_url;
+                                  let musicId = r.music_id;
+                                  
+                                  // audio_url이 없고 music_id가 있으면 오디오 URL 가져오기
+                                  if (!audioUrl && musicId) {
+                                    try {
+                                      const playRes = await axios.get<{ audio_url: string }>(
+                                        `${API_BASE}/tracks/${musicId}/play`,
+                                        { headers: { "Content-Type": "application/json" } }
+                                      );
+                                      audioUrl = playRes.data.audio_url;
+                                      console.log(`[SearchAll] ✅ 곡 ${r.music_name} (music_id: ${musicId}) 오디오 URL 가져오기 성공:`, audioUrl);
+                                    } catch (err) {
+                                      console.error(`[SearchAll] ❌ 곡 ${r.music_name} (music_id: ${musicId}) 재생 URL 가져오기 실패:`, err);
+                                    }
+                                  }
+                                  
+                                  // 앨범 이미지 찾기
+                                  let coverUrl: string | undefined = undefined;
+                                  if (r.album_image) {
+                                    const albumImage = r.album_image;
+                                    if (albumImage.startsWith("http") || albumImage.startsWith("//")) {
+                                      coverUrl = albumImage;
+                                    } else if (API_BASE && albumImage.startsWith("/")) {
+                                      coverUrl = `${API_BASE.replace("/api/v1", "")}${albumImage}`;
+                                    } else {
+                                      coverUrl = albumImage;
+                                    }
+                                  } else if (r.album_id) {
+                                    // 앨범 이미지가 없으면 앨범 정보에서 가져오기
+                                    const album = apiAlbums.find((a) => a.id === String(r.album_id));
+                                    if (album?.album_image) {
+                                      const albumImage = album.album_image;
+                                      if (albumImage.startsWith("http") || albumImage.startsWith("//")) {
+                                        coverUrl = albumImage;
+                                      } else if (API_BASE && albumImage.startsWith("/")) {
+                                        coverUrl = `${API_BASE.replace("/api/v1", "")}${albumImage}`;
+                                      } else {
+                                        coverUrl = albumImage;
+                                      }
+                                    }
+                                  }
+                                  
+                                  return {
+                                    id: String(r.itunes_id),
+                                    title: r.music_name,
+                                    artist: r.artist_name,
+                                    album: r.album_name || "",
+                                    duration: r.duration
+                                      ? `${Math.floor(r.duration / 60)}:${(r.duration % 60).toString().padStart(2, "0")}`
+                                      : "0:00",
+                                    audioUrl: audioUrl || undefined,
+                                    coverUrl: coverUrl,
+                                    musicId: musicId || undefined, // music_id 저장
+                                  };
+                                })
+                              );
+                              
+                              // 오디오 URL이 있는 곡들만 필터링
+                              const validTracks = playerTracks.filter((t) => t.audioUrl);
+                              
+                              console.log(`[SearchAll] 아티스트 ${artistData.name}의 곡 재생:`, {
+                                total: playerTracks.length,
+                                valid: validTracks.length,
+                                tracks: validTracks.map((t) => ({ title: t.title, audioUrl: t.audioUrl })),
+                              });
+                              
+                              if (validTracks.length > 0) {
+                                playTracks(validTracks);
+                              } else {
+                                console.warn(`[SearchAll] 재생 가능한 곡이 없습니다.`);
+                              }
+                            } catch (err) {
+                              console.error("[SearchAll] 아티스트 곡 재생 오류:", err);
+                            }
+                          } else if (!isArtist && songData) {
+                            // 곡 재생
+                            try {
+                              // 검색 결과에서 원본 데이터 찾기
+                              const originalResult = searchResults.find((r) => String(r.itunes_id) === songData.id);
+                              
+                              // audio_url이 검색 결과에 있으면 먼저 사용
+                              let audioUrl: string | undefined = originalResult?.audio_url || undefined;
+                              
+                              const apiSong = apiSongs.find((as) => as.id === songData.id);
+                              if (!apiSong) {
+                                console.warn(`[SearchAll] 곡 ${songData.title}을 API 결과에서 찾을 수 없습니다.`);
+                                // audio_url이 있으면 재생 시도
+                                if (audioUrl) {
+                                  const playerTrack: PlayerTrack = {
+                                    id: songData.id,
+                                    title: songData.title,
+                                    artist: songData.artist,
+                                    album: songData.albumName || "",
+                                    duration: songData.duration,
+                                    audioUrl: audioUrl,
+                                    coverUrl: undefined,
+                                  };
+                                  console.log(`[SearchAll] 곡 재생 시작 (검색 결과 audio_url 사용):`, playerTrack);
+                                  playTracks([playerTrack]);
+                                }
+                                return;
+                              }
+                              
+                              // music_id 찾기 (album_id를 통해)
+                              let musicId: number | null = null;
+                              if (apiSong.albumId && !audioUrl) {
+                                try {
+                                  const albumRes = await axios.get<{
+                                    album_id: number;
+                                    tracks: Array<{ music_id: number; music_name: string }>;
+                                  }>(`${API_BASE}/albums/${apiSong.albumId}/`, {
+                                    headers: { "Content-Type": "application/json" },
+                                  });
+                                  
+                                  const track = albumRes.data.tracks.find(
+                                    (t) => t.music_name === songData.title
+                                  );
+                                  if (track) {
+                                    musicId = track.music_id;
+                                    console.log(`[SearchAll] ✅ 곡 ${songData.title}의 music_id 찾음: ${musicId}`);
+                                  } else {
+                                    console.warn(`[SearchAll] ⚠️ 곡 ${songData.title}을 앨범 ${apiSong.albumId}의 트랙 목록에서 찾을 수 없습니다.`);
+                                  }
+                                } catch (err) {
+                                  console.error(`[SearchAll] ❌ 앨범 ${apiSong.albumId} 정보 가져오기 실패:`, err);
+                                }
+                              }
+                              
+                              // audio_url이 없고 music_id가 있으면 오디오 URL 가져오기
+                              if (!audioUrl && musicId) {
+                                try {
+                                  const playRes = await axios.get<{ audio_url: string }>(
+                                    `${API_BASE}/tracks/${musicId}/play`,
+                                    { headers: { "Content-Type": "application/json" } }
+                                  );
+                                  audioUrl = playRes.data.audio_url;
+                                  console.log(`[SearchAll] ✅ 곡 ${songData.title} (music_id: ${musicId}) 오디오 URL 가져오기 성공:`, audioUrl);
+                                } catch (err) {
+                                  console.error(`[SearchAll] ❌ 곡 ${songData.title} (music_id: ${musicId}) 재생 URL 가져오기 실패:`, err);
+                                }
+                              }
+                              
+                              // 앨범 이미지 찾기
+                              let coverUrl: string | undefined = undefined;
+                              if (apiSong.albumId) {
+                                const album = apiAlbums.find((a) => a.id === String(apiSong.albumId));
+                                if (album?.album_image) {
+                                  const albumImage = album.album_image;
+                                  if (albumImage.startsWith("http") || albumImage.startsWith("//")) {
+                                    coverUrl = albumImage;
+                                  } else if (API_BASE && albumImage.startsWith("/")) {
+                                    coverUrl = `${API_BASE.replace("/api/v1", "")}${albumImage}`;
+                                  } else {
+                                    coverUrl = albumImage;
+                                  }
+                                }
+                              }
+                              
+                              if (!audioUrl) {
+                                console.warn(`[SearchAll] ⚠️ 곡 ${songData.title}의 오디오 URL이 없어 재생할 수 없습니다.`);
+                                return;
+                              }
+                              
+                              const playerTrack: PlayerTrack = {
+                                id: songData.id,
+                                title: songData.title,
+                                artist: songData.artist,
+                                album: songData.albumName || "",
+                                duration: songData.duration,
+                                audioUrl: audioUrl,
+                                coverUrl: coverUrl,
+                                musicId: musicId || undefined, // music_id 저장
+                              };
+                              
+                              console.log(`[SearchAll] 곡 재생 시작:`, playerTrack);
+                              playTracks([playerTrack]);
+                            } catch (err) {
+                              console.error("[SearchAll] 곡 재생 오류:", err);
+                            }
+                          }
+                        }}
+                        className="
+                          absolute right-0 bottom-4
+                          -translate-x-4 -translate-y-4
+                          w-12 h-12 rounded-full
+                          bg-[#AFDEE2] text-[#1d1d1d]
+                          grid place-items-center
+                          shadow-lg
+                          hover:bg-[#87B2B6] transition
 
-                            opacity-0 translate-y-1 pointer-events-none
-                            group-hover:opacity-100 group-hover:translate-y-0 group-hover:pointer-events-auto
-                          "
-                          aria-label="재생"
-                          title="재생"
-                        >
-                          <MdPlayArrow size={26} />
-                        </button>
-                      )}
+                          opacity-0 translate-y-1 pointer-events-none
+                          group-hover:opacity-100 group-hover:translate-y-0 group-hover:pointer-events-auto
+                        "
+                        aria-label="재생"
+                        title="재생"
+                      >
+                        <MdPlayArrow size={26} />
+                      </button>
                     </div>
                   );
                 })()}

--- a/src/pages/search/SearchSong.tsx
+++ b/src/pages/search/SearchSong.tsx
@@ -443,6 +443,7 @@ export default function SearchSong() {
       duration: s.duration,
       audioUrl: audioUrl || undefined,
       coverUrl: coverUrl,
+      musicId: musicId || undefined, // music_id 저장
     };
   };
 

--- a/src/pages/song/NowPlayingPage.tsx
+++ b/src/pages/song/NowPlayingPage.tsx
@@ -1,7 +1,8 @@
-import { useMemo, useState, useEffect, useRef } from "react";
+import { useMemo, useState, useEffect, useRef, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import { MdFavorite, MdMoreHoriz } from "react-icons/md";
 import { MdQueueMusic, MdClose, MdDelete, MdDragIndicator } from "react-icons/md";
+import { MdPlayArrow, MdPause, MdSkipNext, MdSkipPrevious, MdShuffle, MdRepeat } from "react-icons/md";
 import { RiDashboardFill } from "react-icons/ri";
 import { GrContract } from "react-icons/gr";
 import { usePlayer } from "../../player/PlayerContext";
@@ -10,39 +11,376 @@ import {
     toggleTrackLike,
     subscribePlaylists,
 } from "../../mocks/playlistMock";
+import axios from "axios";
 
-type LyricLine = { t: number; text: string }; // t = 시작초
+type LyricLine = { t: number; text: string; timestamp?: string | null }; // t = 시작초, timestamp = 타임스탬프 문자열
 
 export default function NowPlayingPage() {
     const navigate = useNavigate();
 
-    const { current, queue, history, progress, removeFromQueue, moveQueueItem } =
-        usePlayer();
+    const { 
+        current, 
+        queue, 
+        history, 
+        progress, 
+        duration,
+        isPlaying,
+        toggle,
+        seek,
+        removeFromQueue, 
+        moveQueueItem,
+        shuffleQueue,
+        seekBackward,
+        seekForward,
+        nextTrack,
+        previousTrack,
+        repeatMode,
+        toggleRepeat,
+    } = usePlayer();
 
     const hasTrack = !!current;
+    
+    const API_BASE = import.meta.env.VITE_API_BASE_URL as string | undefined;
+    
+    // 이미지 URL 처리 함수
+    const processImageUrl = useCallback((url: string | null | undefined): string | null => {
+        if (!url) return null;
+        
+        const API_BASE = import.meta.env.VITE_API_BASE_URL as string | undefined;
+        
+        if (url.startsWith("http://") || url.startsWith("https://") || url.startsWith("//")) {
+            return url;
+        }
+        
+        if (API_BASE && url.startsWith("/")) {
+            return `${API_BASE.replace("/api/v1", "")}${url}`;
+        }
+        
+        return url;
+    }, []);
+    
+    // 메인 앨범 이미지 (image_large_square 우선, 없으면 coverUrl)
+    const mainAlbumImage = useMemo(() => {
+        if (!current) return null;
+        // TODO: API에서 image_large_square 필드 가져오기
+        // 현재는 coverUrl 사용
+        return current.coverUrl || null;
+    }, [current]);
 
     // ✅ 가사 패널 (bottom sheet)
     const [lyricsOpen, setLyricsOpen] = useState(false);
-
-    // ✅ 임시 가사(나중에 current.id로 연결)
-    const LYRICS: LyricLine[] = [
-        { t: 0, text: "첫 줄 가사" },
-        { t: 6, text: "둘째 줄 가사" },
-        { t: 12, text: "셋째 줄 가사" },
-        { t: 18, text: "넷째 줄 가사" },
-        { t: 24, text: "다섯째 줄 가사" },
-        { t: 30, text: "여섯째 줄 가사" },
-    ];
-
-    const currentLyricIndex = useMemo(() => {
-        const p = Number.isFinite(progress) ? progress : 0;
-        let idx = 0;
-        for (let i = 0; i < LYRICS.length; i++) {
-        if (LYRICS[i].t <= p) idx = i;
-        else break;
+    
+    // ✅ 가사 데이터 상태
+    const [lyrics, setLyrics] = useState<LyricLine[]>([]);
+    const [lyricsLoading, setLyricsLoading] = useState(false);
+    const [lyricsError, setLyricsError] = useState<string | null>(null);
+    
+    // ✅ 가사 API 호출
+    useEffect(() => {
+        if (!current || !API_BASE) {
+            setLyrics([]);
+            setLyricsError(null);
+            return;
         }
-        return idx;
-    }, [progress, LYRICS]);
+        
+        const controller = new AbortController();
+        
+        (async () => {
+            try {
+                setLyricsLoading(true);
+                setLyricsError(null);
+                
+                // ✅ current.musicId가 이미 있으면 바로 사용 (검색 불필요)
+                let musicId: number | null = current.musicId || null;
+                
+                if (musicId) {
+                    console.log(`[NowPlayingPage] ✅ current.musicId 사용:`, {
+                        musicId,
+                        title: current.title,
+                    });
+                } else {
+                    // current.id가 itunes_id일 수 있으므로, music_id를 찾아야 함
+                    const itunesId = Number(current.id);
+                    if (isNaN(itunesId)) {
+                        console.warn(`[NowPlayingPage] 가사 API 호출 실패: current.id가 숫자가 아니고 musicId도 없습니다.`, {
+                            id: current.id,
+                            title: current.title,
+                        });
+                        setLyrics([]);
+                        setLyricsError(null);
+                        setLyricsLoading(false);
+                        return;
+                    }
+                    
+                    // 검색 API를 통해 music_id 찾기
+                    try {
+                    // 검색 API 엔드포인트: /api/v1/search?q=... (SearchAll.tsx 참고)
+                    const searchUrl = `${API_BASE}/search?q=${encodeURIComponent(current.title)}`;
+                    console.log(`[NowPlayingPage] 검색 API 호출 (music_id 찾기):`, {
+                        title: current.title,
+                        url: searchUrl,
+                    });
+                    
+                    const searchRes = await fetch(searchUrl, {
+                        method: "GET",
+                        signal: controller.signal,
+                        headers: { "Content-Type": "application/json" },
+                    });
+                    
+                    if (searchRes.ok) {
+                        const searchData = await searchRes.json();
+                        console.log(`[NowPlayingPage] 검색 API 응답:`, {
+                            resultsCount: searchData.results?.length || 0,
+                            firstResult: searchData.results?.[0],
+                        });
+                        
+                        // 검색 결과에서 itunes_id로 매칭되는 곡 찾기
+                        const matchedResult = searchData.results?.find(
+                            (r: any) => r.itunes_id === itunesId
+                        );
+                        
+                        console.log(`[NowPlayingPage] 매칭된 검색 결과:`, {
+                            matched: !!matchedResult,
+                            hasMusicId: !!matchedResult?.music_id,
+                            hasAlbumId: !!matchedResult?.album_id,
+                            result: matchedResult,
+                        });
+                        
+                        if (matchedResult?.music_id) {
+                            musicId = matchedResult.music_id;
+                            console.log(`[NowPlayingPage] ✅ music_id 찾음:`, {
+                                musicId,
+                                title: current.title,
+                            });
+                        } else if (matchedResult?.album_id) {
+                            // music_id가 없으면 앨범 API를 통해 찾기 시도
+                            try {
+                                const albumRes = await fetch(
+                                    `${API_BASE}/albums/${matchedResult.album_id}/`,
+                                    {
+                                        method: "GET",
+                                        signal: controller.signal,
+                                        headers: { "Content-Type": "application/json" },
+                                    }
+                                );
+                                
+                                if (albumRes.ok) {
+                                    const albumData = await albumRes.json();
+                                    const matchedTrack = albumData.tracks?.find(
+                                        (t: any) => t.music_name === current.title
+                                    );
+                                    
+                                    if (matchedTrack?.music_id) {
+                                        musicId = matchedTrack.music_id;
+                                        console.log(`[NowPlayingPage] ✅ 앨범 API를 통해 music_id 찾음:`, {
+                                            musicId,
+                                            title: current.title,
+                                        });
+                                    }
+                                }
+                            } catch (e) {
+                                if ((e as DOMException)?.name !== "AbortError") {
+                                    console.warn(`[NowPlayingPage] 앨범 API 호출 실패:`, e);
+                                }
+                            }
+                        }
+                    } else if (searchRes.status !== 404) {
+                        // 404가 아닌 경우에만 경고 (404는 검색 결과가 없는 것)
+                        console.warn(`[NowPlayingPage] 검색 API 오류: ${searchRes.status}`);
+                    }
+                    } catch (e) {
+                        // AbortError는 정상적인 cleanup이므로 무시
+                        if ((e as DOMException)?.name !== "AbortError") {
+                            console.warn(`[NowPlayingPage] 검색 API 호출 실패:`, e);
+                        }
+                    }
+                    
+                    // music_id를 찾지 못했으면 아티스트와 제목으로 검색 시도
+                    if (!musicId) {
+                        try {
+                            const combinedSearch = `${current.artist} ${current.title}`;
+                            const combinedSearchUrl = `${API_BASE}/search?q=${encodeURIComponent(combinedSearch)}`;
+                            const combinedSearchRes = await fetch(combinedSearchUrl, {
+                                method: "GET",
+                                signal: controller.signal,
+                                headers: { "Content-Type": "application/json" },
+                            });
+                            
+                            if (combinedSearchRes.ok) {
+                                const combinedSearchData = await combinedSearchRes.json();
+                                // 아티스트와 제목으로 매칭
+                                const matchedResult = combinedSearchData.results?.find(
+                                    (r: any) => 
+                                        r.artist_name === current.artist && 
+                                        r.music_name === current.title
+                                );
+                                
+                            if (matchedResult?.music_id) {
+                                musicId = matchedResult.music_id;
+                                console.log(`[NowPlayingPage] ✅ 조합 검색으로 music_id 찾음:`, {
+                                    musicId,
+                                    title: current.title,
+                                });
+                            }
+                            }
+                        } catch (e) {
+                            if ((e as DOMException)?.name !== "AbortError") {
+                                console.warn(`[NowPlayingPage] 조합 검색 API 호출 실패:`, e);
+                            }
+                        }
+                    }
+                    
+                    // 여전히 music_id를 찾지 못했으면 가사를 불러올 수 없음
+                    if (!musicId) {
+                        console.warn(`[NowPlayingPage] ⚠️ music_id를 찾을 수 없어 가사를 불러올 수 없습니다:`, {
+                            title: current.title,
+                            artist: current.artist,
+                        });
+                        setLyrics([]);
+                        setLyricsError(null); // 에러 메시지 없이 빈 가사로 처리
+                        setLyricsLoading(false);
+                        return;
+                    }
+                } // else 블록 닫기
+                
+                // 가사 API 호출: /api/v1/{music_id}/
+                const lyricsUrl = `${API_BASE}/${musicId}/`;
+                console.log(`[NowPlayingPage] 가사 API 호출:`, {
+                    musicId,
+                    url: lyricsUrl,
+                    title: current.title,
+                });
+                
+                const res = await fetch(lyricsUrl, {
+                    method: "GET",
+                    signal: controller.signal,
+                    headers: { "Content-Type": "application/json" },
+                });
+                
+                if (!res.ok) {
+                    if (res.status === 404) {
+                        // 404 응답: 해당 music_id의 트랙이 없거나 가사가 없는 경우
+                        // 응답 본문 확인 (디버깅용)
+                        let errorBody = null;
+                        try {
+                            const text = await res.text();
+                            if (text) {
+                                try {
+                                    errorBody = JSON.parse(text);
+                                } catch {
+                                    errorBody = text;
+                                }
+                            }
+                        } catch (e) {
+                            // 응답 본문 읽기 실패는 무시
+                        }
+                        
+                        console.warn(`[NowPlayingPage] 가사 API 404 응답:`, {
+                            musicId,
+                            title: current.title,
+                            url: res.url, // 실제 호출된 URL
+                            status: res.status,
+                            errorBody,
+                        });
+                        setLyrics([]);
+                        setLyricsError(null); // 에러 메시지 없이 빈 가사로 처리
+                        setLyricsLoading(false);
+                        return;
+                    }
+                    throw new Error(`가사 API 오류: ${res.status}`);
+                }
+                
+                const data = await res.json();
+                
+                console.log(`[NowPlayingPage] 가사 API 응답:`, {
+                    musicId,
+                    title: current.title,
+                    hasLyrics: !!data.lyrics,
+                    lyricsType: typeof data.lyrics,
+                    lyricsLength: typeof data.lyrics === "string" ? data.lyrics.length : data.lyrics?.length || 0,
+                    dataKeys: Object.keys(data),
+                    fullResponse: data, // 전체 응답 구조 확인용
+                });
+                
+                // 가사 파싱: lyrics 필드에서 타임스탬프와 텍스트 추출
+                let parsedLyrics: LyricLine[] = [];
+                
+                if (data.lyrics && typeof data.lyrics === "string") {
+                    // 타임스탬프 형식: [00:00.56] 가사 텍스트
+                    const lines = data.lyrics.split(/\r?\n/).filter((line: string) => line.trim() !== "");
+                    
+                    parsedLyrics = lines.map((line: string) => {
+                        // 타임스탬프 추출: [00:00.56] 또는 [00:03.38] 형식
+                        const timestampMatch = line.match(/\[(\d{2}):(\d{2})\.(\d{2})\]/);
+                        let timestampSeconds = 0;
+                        
+                        if (timestampMatch) {
+                            const minutes = parseInt(timestampMatch[1], 10);
+                            const seconds = parseInt(timestampMatch[2], 10);
+                            const centiseconds = parseInt(timestampMatch[3], 10);
+                            timestampSeconds = minutes * 60 + seconds + centiseconds / 100;
+                            
+                            // 타임스탬프 제거하고 텍스트만 추출
+                            const text = line.replace(/\[\d{2}:\d{2}\.\d{2}\]\s*/, "").trim();
+                            return {
+                                t: timestampSeconds,
+                                text: text || line.trim(), // 타임스탬프만 있고 텍스트가 없으면 전체 라인 사용
+                                timestamp: timestampMatch[0], // 타임스탬프 문자열 저장
+                            };
+                        } else {
+                            // 타임스탬프가 없는 경우
+                            return {
+                                t: 0,
+                                text: line.trim(),
+                                timestamp: null,
+                            };
+                        }
+                    });
+                } else {
+                    // lyrics 필드가 없거나 다른 형식인 경우
+                    console.warn(`[NowPlayingPage] 가사 형식이 예상과 다릅니다:`, {
+                        musicId,
+                        lyricsType: typeof data.lyrics,
+                    });
+                    setLyrics([]);
+                    setLyricsError(null);
+                    return;
+                }
+                
+                // 빈 줄 제거
+                parsedLyrics = parsedLyrics.filter((line) => line.text && line.text.trim() !== "");
+                
+                // 타임스탬프 기준으로 정렬
+                parsedLyrics.sort((a, b) => a.t - b.t);
+                
+                console.log(`[NowPlayingPage] ✅ 가사 파싱 완료:`, {
+                    musicId,
+                    title: current.title,
+                    lineCount: parsedLyrics.length,
+                    firstLines: parsedLyrics.slice(0, 3).map((l) => ({
+                        timestamp: l.timestamp,
+                        text: l.text.substring(0, 30),
+                    })),
+                });
+                
+                setLyrics(parsedLyrics);
+            } catch (e: unknown) {
+                if ((e as DOMException)?.name === "AbortError") return;
+                console.error(`[NowPlayingPage] ❌ 가사 로드 실패:`, {
+                    id: current.id,
+                    title: current.title,
+                    error: e,
+                });
+                setLyricsError(e instanceof Error ? e.message : "가사를 불러올 수 없습니다.");
+                setLyrics([]);
+            } finally {
+                setLyricsLoading(false);
+            }
+        })();
+        
+        return () => controller.abort();
+    }, [current, API_BASE]);
+
 
     // ✅ 좌/우 패널 상태
     const [leftOpen, setLeftOpen] = useState(false); // 분석 대시보드
@@ -102,14 +440,6 @@ export default function NowPlayingPage() {
         });
     };
 
-    const currentLineRef = useRef<HTMLDivElement | null>(null);
-    useEffect(() => {
-        if (!lyricsOpen) return;
-        currentLineRef.current?.scrollIntoView({
-        block: "center",
-        behavior: "smooth",
-        });
-    }, [lyricsOpen, currentLyricIndex]);
 
     // ✅ 드래그앤드롭(핸들만 드래그)
     const [dragIndex, setDragIndex] = useState<number | null>(null);
@@ -237,9 +567,36 @@ export default function NowPlayingPage() {
                 <div className="h-full pt-4 bg-[#333333] overflow-hidden">
                 <div className="h-full flex flex-col items-center justify-center px-6">
                     <div className="w-full max-w-[860px] flex flex-col items-center gap-4">
-                    {/* 앨범아트 */}
-                    <div className="w-[360px] aspect-square rounded-3xl bg-white/25 border border-white/10 flex items-center justify-center">
-                        <span className="text-white/60 text-sm">사진</span>
+                    {/* 앨범아트 - image_large_square 사용 */}
+                    <div className="w-[360px] aspect-square rounded-3xl bg-white/25 border border-white/10 overflow-hidden relative">
+                        {hasTrack && mainAlbumImage ? (
+                            <>
+                                <img
+                                    src={processImageUrl(mainAlbumImage) || undefined}
+                                    alt={current.title}
+                                    className="w-full h-full object-cover relative z-10"
+                                    onError={(e) => {
+                                        console.error(`[NowPlayingPage] ❌ 메인 앨범 이미지 로드 실패:`, {
+                                            title: current.title,
+                                            image_url: mainAlbumImage,
+                                        });
+                                        (e.target as HTMLImageElement).style.display = "none";
+                                    }}
+                                    onLoad={() => {
+                                        console.log(`[NowPlayingPage] ✅ 메인 앨범 이미지 로드 성공:`, {
+                                            title: current.title,
+                                            image_url: mainAlbumImage,
+                                        });
+                                    }}
+                                    loading="lazy"
+                                />
+                                <div className="absolute inset-0 bg-white/25 animate-pulse z-0" />
+                            </>
+                        ) : (
+                            <div className="w-full h-full flex items-center justify-center">
+                                <span className="text-white/60 text-sm">사진</span>
+                            </div>
+                        )}
                     </div>
 
                     <div className="min-w-0 text-center">
@@ -420,7 +777,25 @@ export default function NowPlayingPage() {
                                 ) : null}
                             </div>
 
-                            <div className="h-10 w-10 rounded-xl bg-white/20 border border-white/10" />
+                            {/* 앨범 이미지 - square 축소 사용 */}
+                            <div className="h-10 w-10 rounded-xl bg-white/20 border border-white/10 overflow-hidden relative flex-shrink-0">
+                                {t.coverUrl ? (
+                                    <>
+                                        <img
+                                            src={processImageUrl(t.coverUrl) || undefined}
+                                            alt={t.title}
+                                            className="w-full h-full object-cover relative z-10"
+                                            onError={(e) => {
+                                                (e.target as HTMLImageElement).style.display = "none";
+                                            }}
+                                            loading="lazy"
+                                        />
+                                        <div className="absolute inset-0 bg-white/20 animate-pulse z-0" />
+                                    </>
+                                ) : (
+                                    <div className="w-full h-full bg-white/20" />
+                                )}
+                            </div>
 
                             <div className="min-w-0">
                                 <div className="text-sm font-semibold truncate">
@@ -536,29 +911,186 @@ export default function NowPlayingPage() {
                 </div>
 
                 <div className="h-[52vh] px-6 py-5 overflow-y-auto">
-                <div className="space-y-3">
-                    {LYRICS.map((line, i) => {
-                    const isCurrent = i === currentLyricIndex;
-                    const isPast = i < currentLyricIndex;
-
-                    return (
-                        <div
-                        key={line.t}
-                        ref={isCurrent ? currentLineRef : null}
-                        className={[
-                            "text-lg leading-8 transition-colors",
-                            isCurrent
-                            ? "text-[#F6F6F6] font-semibold"
-                            : isPast
-                            ? "text-white/35"
-                            : "text-white/65",
-                        ].join(" ")}
-                        >
-                        {line.text}
-                        </div>
-                    );
-                    })}
+                {lyricsLoading ? (
+                    <div className="flex items-center justify-center h-full">
+                        <div className="text-sm text-white/60">가사를 불러오는 중...</div>
+                    </div>
+                ) : lyricsError ? (
+                    <div className="flex items-center justify-center h-full">
+                        <div className="text-sm text-white/60">{lyricsError}</div>
+                    </div>
+                ) : lyrics.length === 0 ? (
+                    <div className="flex items-center justify-center h-full">
+                        <div className="text-sm text-white/60">가사가 없습니다.</div>
+                    </div>
+                ) : (
+                    <div className="space-y-3">
+                        {lyrics.map((line, i) => (
+                            <div
+                                key={`${line.t}-${i}`}
+                                className="text-lg leading-8 text-white/80 flex items-start gap-3"
+                            >
+                                {line.timestamp && (
+                                    <span className="text-white/50 text-sm font-mono flex-shrink-0 mt-1">
+                                        {line.timestamp}
+                                    </span>
+                                )}
+                                <span className="flex-1">{line.text}</span>
+                            </div>
+                        ))}
+                    </div>
+                )}
                 </div>
+                
+                {/* 하단 플레이어 컨트롤 */}
+                <div className="border-t border-white/10 bg-[#2d2d2d] px-6 py-4">
+                    <div className="flex flex-col items-center gap-3">
+                        {/* 컨트롤 버튼들 */}
+                        <div className="flex items-center gap-4">
+                            {/* 셔플 */}
+                            <button
+                                type="button"
+                                onClick={shuffleQueue}
+                                disabled={!hasTrack}
+                                className={[
+                                    "transition",
+                                    hasTrack ? "text-white/60 hover:text-white" : "text-white/30 cursor-not-allowed",
+                                ].join(" ")}
+                                aria-label="셔플"
+                                title="재생 대기 곡들 셔플"
+                            >
+                                <MdShuffle size={20} />
+                            </button>
+
+                            {/* 이전 곡 */}
+                            <button
+                                type="button"
+                                onClick={previousTrack}
+                                disabled={!hasTrack}
+                                className={[
+                                    "transition",
+                                    hasTrack ? "text-white/60 hover:text-white" : "text-white/30 cursor-not-allowed",
+                                ].join(" ")}
+                                aria-label="이전 곡"
+                                title="이전 곡"
+                            >
+                                <MdSkipPrevious size={24} />
+                            </button>
+
+                            {/* 재생 / 일시정지 */}
+                            <button
+                                type="button"
+                                onClick={toggle}
+                                disabled={!hasTrack}
+                                className={[
+                                    "h-10 w-10 rounded-full flex items-center justify-center transition",
+                                    hasTrack
+                                        ? "bg-[#E4524D] text-white hover:brightness-110"
+                                        : "bg-white/10 text-white/40 cursor-not-allowed",
+                                ].join(" ")}
+                                aria-label={isPlaying ? "일시정지" : "재생"}
+                                title={isPlaying ? "일시정지" : "재생"}
+                            >
+                                {isPlaying ? <MdPause size={24} /> : <MdPlayArrow size={24} />}
+                            </button>
+
+                            {/* 다음 곡 */}
+                            <button
+                                type="button"
+                                onClick={nextTrack}
+                                disabled={!hasTrack}
+                                className={[
+                                    "transition",
+                                    hasTrack ? "text-white/60 hover:text-white" : "text-white/30 cursor-not-allowed",
+                                ].join(" ")}
+                                aria-label="다음 곡"
+                                title="다음 곡"
+                            >
+                                <MdSkipNext size={24} />
+                            </button>
+
+                            {/* 반복 */}
+                            <button
+                                type="button"
+                                onClick={toggleRepeat}
+                                disabled={!hasTrack}
+                                className={[
+                                    "transition",
+                                    hasTrack
+                                        ? repeatMode === "one"
+                                            ? "text-[#AFDEE2]"
+                                            : "text-white/60 hover:text-white"
+                                        : "text-white/30 cursor-not-allowed",
+                                ].join(" ")}
+                                aria-label="반복"
+                                title={repeatMode === "one" ? "한 곡 반복" : "반복 끄기"}
+                            >
+                                <MdRepeat size={20} />
+                            </button>
+                        </div>
+
+                        {/* 진행 바 */}
+                        <div className="w-full flex items-center gap-3">
+                            <span className="text-xs text-white/60 tabular-nums min-w-[40px] text-right">
+                                {(() => {
+                                    const p = Number.isFinite(progress) ? progress : 0;
+                                    const m = Math.floor(p / 60);
+                                    const s = Math.floor(p % 60);
+                                    return `${m}:${s.toString().padStart(2, "0")}`;
+                                })()}
+                            </span>
+                            <div
+                                className="flex-1 h-1 bg-white/10 rounded-full relative cursor-pointer"
+                                onClick={(e) => {
+                                    if (!hasTrack || duration <= 0) return;
+                                    const rect = e.currentTarget.getBoundingClientRect();
+                                    const x = e.clientX - rect.left;
+                                    const ratio = Math.max(0, Math.min(1, x / rect.width));
+                                    seek(ratio * duration);
+                                }}
+                                onPointerDown={(e) => {
+                                    if (!hasTrack || duration <= 0) return;
+                                    e.preventDefault();
+                                    const rect = e.currentTarget.getBoundingClientRect();
+                                    const setSeek = (clientX: number) => {
+                                        const x = clientX - rect.left;
+                                        const ratio = Math.max(0, Math.min(1, x / rect.width));
+                                        seek(ratio * duration);
+                                    };
+                                    setSeek(e.clientX);
+                                    e.currentTarget.setPointerCapture(e.pointerId);
+                                    const onMove = (ev: PointerEvent) => setSeek(ev.clientX);
+                                    const onUp = () => {
+                                        window.removeEventListener("pointermove", onMove);
+                                        window.removeEventListener("pointerup", onUp);
+                                    };
+                                    window.addEventListener("pointermove", onMove);
+                                    window.addEventListener("pointerup", onUp);
+                                }}
+                            >
+                                <div
+                                    className="h-full bg-[#E4524D] rounded-full transition-all"
+                                    style={{
+                                        width: `${duration > 0 ? Math.min(100, (progress / duration) * 100) : 0}%`,
+                                    }}
+                                />
+                                <div
+                                    className="absolute top-1/2 -translate-y-1/2 -translate-x-1/2 w-3 h-3 rounded-full bg-[#E4524D] transition-all"
+                                    style={{
+                                        left: `${duration > 0 ? Math.min(100, (progress / duration) * 100) : 0}%`,
+                                    }}
+                                />
+                            </div>
+                            <span className="text-xs text-white/60 tabular-nums min-w-[40px]">
+                                {(() => {
+                                    const d = Number.isFinite(duration) ? duration : 0;
+                                    const m = Math.floor(d / 60);
+                                    const s = Math.floor(d % 60);
+                                    return `${m}:${s.toString().padStart(2, "0")}`;
+                                })()}
+                            </span>
+                        </div>
+                    </div>
                 </div>
             </div>
             </div>

--- a/src/player/PlayerContext.tsx
+++ b/src/player/PlayerContext.tsx
@@ -17,6 +17,7 @@ export type PlayerTrack = {
     coverUrl?: string;
     audioUrl?: string;
     likeCount?: number;
+    musicId?: number; // API의 music_id (가사 조회 등에 사용)
 };
 
 export type PlayerContextValue = {
@@ -46,6 +47,15 @@ export type PlayerContextValue = {
     // ✅ 추가: 큐 편집
     removeFromQueue: (trackId: string) => void;
     moveQueueItem: (fromIndex: number, toIndex: number) => void;
+    
+    // ✅ 플레이어 컨트롤
+    shuffleQueue: () => void;
+    seekBackward: (seconds?: number) => void;
+    seekForward: (seconds?: number) => void;
+    nextTrack: () => void;
+    previousTrack: () => void;
+    repeatMode: 'off' | 'one';
+    toggleRepeat: () => void;
   };
   
   const PlayerContext = createContext<PlayerContextValue | null>(null);
@@ -73,16 +83,33 @@ export type PlayerContextValue = {
   
     const [queue, setQueue] = useState<PlayerTrack[]>([]);
     const [history, setHistory] = useState<PlayerTrack[]>([]);
+    
+    // ✅ 반복 모드: 'off' | 'one'
+    const [repeatMode, setRepeatMode] = useState<'off' | 'one'>('off');
+    // ✅ 반복 모드를 ref로도 저장 (handleEnded에서 최신 값 참조용)
+    const repeatModeRef = useRef<'off' | 'one'>('off');
   
     // ✅ 실제 오디오 요소
     const audioRef = useRef<HTMLAudioElement | null>(null);
     // ✅ 현재 트랙을 ref로도 저장 (에러 핸들러에서 최신 값 참조용)
     const currentRef = useRef<PlayerTrack | null>(null);
+    // ✅ 재생 상태를 ref로도 저장 (셔플 등 상태 업데이트 시 재생 유지용)
+    const isPlayingRef = useRef<boolean>(false);
   
     // ✅ current 변경 시 ref도 업데이트
     useEffect(() => {
       currentRef.current = current;
     }, [current]);
+    
+    // ✅ isPlaying 변경 시 ref도 업데이트
+    useEffect(() => {
+      isPlayingRef.current = isPlaying;
+    }, [isPlaying]);
+    
+    // ✅ repeatMode 변경 시 ref도 업데이트
+    useEffect(() => {
+      repeatModeRef.current = repeatMode;
+    }, [repeatMode]);
 
     // ✅ 볼륨 상태 (0~1)
     const [volume, _setVolume] = useState(0.8);
@@ -109,6 +136,40 @@ export type PlayerContextValue = {
       };
 
       const handleEnded = () => {
+        // ref에서 최신 반복 모드와 현재 곡 가져오기
+        const currentRepeatMode = repeatModeRef.current;
+        const currentTrack = currentRef.current;
+        
+        console.log('[PlayerContext] 곡 재생 종료:', {
+          repeatMode: currentRepeatMode,
+          currentTrack: currentTrack?.title,
+        });
+        
+        // 반복 모드가 'one'이면 현재 곡 다시 재생 (다음 곡으로 넘어가지 않음)
+        if (currentRepeatMode === 'one' && currentTrack) {
+          console.log('[PlayerContext] 한곡 반복 모드: 같은 곡 다시 재생');
+          const audio = audioRef.current;
+          if (audio) {
+            // 오디오를 처음부터 다시 재생
+            audio.currentTime = 0;
+            setProgress(0);
+            const playPromise = audio.play();
+            if (playPromise !== undefined) {
+              playPromise.catch((e) => {
+                // AbortError는 재생 중 pause()가 호출된 경우이므로 무시
+                if (e.name === 'AbortError') {
+                  return;
+                }
+                console.error("[PlayerContext] 반복 재생 실패:", e);
+                setIsPlaying(false);
+              });
+            }
+          }
+          return;
+        }
+        
+        // 반복 모드가 'off'이면 다음 곡 재생
+        console.log('[PlayerContext] 반복 모드 off: 다음 곡 재생');
         setQueue((q) => {
           if (q.length > 0) {
             const nextTrack = q[0];
@@ -232,14 +293,61 @@ export type PlayerContextValue = {
     // ✅ isPlaying 변경 시 재생/일시정지
     useEffect(() => {
       const audio = audioRef.current;
-      if (!audio || !current?.audioUrl) return;
+      if (!audio || !current?.audioUrl) {
+        console.log('[PlayerContext] isPlaying useEffect 스킵:', {
+          hasAudio: !!audio,
+          hasCurrent: !!current,
+          hasAudioUrl: !!current?.audioUrl,
+        });
+        return;
+      }
+
+      console.log('[PlayerContext] isPlaying useEffect 실행:', {
+        isPlaying,
+        currentTitle: current.title,
+        audioSrc: audio.src,
+        audioPaused: audio.paused,
+        currentAudioUrl: current.audioUrl,
+      });
 
       if (isPlaying) {
-        audio.play().catch((e) => {
-          console.error("오디오 재생 실패:", e);
-          setIsPlaying(false);
+        // 오디오가 이미 같은 곡을 재생 중이고 일시정지 상태가 아니면 재생하지 않음
+        // (셔플 등으로 인한 불필요한 재시작 방지)
+        const currentSrc = audio.src;
+        const newSrc = current.audioUrl;
+        const isSameTrack = currentSrc && newSrc && 
+          (currentSrc === newSrc || 
+           currentSrc.includes(newSrc.split('?')[0]) || 
+           newSrc.includes(currentSrc.split('?')[0]));
+        
+        console.log('[PlayerContext] 재생 체크:', {
+          isSameTrack,
+          audioPaused: audio.paused,
+          currentSrc,
+          newSrc,
         });
+        
+        if (isSameTrack && !audio.paused) {
+          // 이미 같은 곡이 재생 중이면 아무것도 하지 않음
+          console.log('[PlayerContext] 같은 곡 재생 중이므로 재생하지 않음');
+          return;
+        }
+        
+        console.log('[PlayerContext] 오디오 재생 시작');
+        const playPromise = audio.play();
+        if (playPromise !== undefined) {
+          playPromise.catch((e) => {
+            // AbortError는 재생 중 pause()가 호출된 경우이므로 무시
+            if (e.name === 'AbortError') {
+              console.log('[PlayerContext] AbortError 무시 (정상 동작)');
+              return;
+            }
+            console.error("[PlayerContext] 오디오 재생 실패:", e);
+            setIsPlaying(false);
+          });
+        }
       } else {
+        console.log('[PlayerContext] 오디오 일시정지');
         audio.pause();
       }
     }, [isPlaying, current]);
@@ -331,6 +439,100 @@ export type PlayerContextValue = {
         return next;
       });
     }, []);
+    
+    // ✅ 셔플: 재생 대기 곡들 셔플 (현재 재생 중인 곡에는 영향 없음)
+    const shuffleQueue = useCallback(() => {
+      console.log('[PlayerContext] 셔플 버튼 클릭');
+      console.log('[PlayerContext] 셔플 전 상태:', {
+        current: current?.title,
+        isPlaying: isPlaying,
+        isPlayingRef: isPlayingRef.current,
+        queueLength: queue.length,
+        audioPaused: audioRef.current?.paused,
+        audioSrc: audioRef.current?.src,
+      });
+      
+      // 현재 재생 상태를 유지하면서 큐만 섞기
+      const currentTrack = current;
+      const currentAudioSrc = audioRef.current?.src;
+      
+      setQueue((q) => {
+        const shuffled = shuffleCopy(q);
+        console.log('[PlayerContext] 셔플 후 큐:', {
+          before: q.length,
+          after: shuffled.length,
+          shuffled: shuffled.map(t => t.title),
+        });
+        return shuffled;
+      });
+      
+      // 셔플 후 상태 확인
+      setTimeout(() => {
+        console.log('[PlayerContext] 셔플 후 상태:', {
+          current: currentTrack?.title,
+          isPlaying: isPlaying,
+          isPlayingRef: isPlayingRef.current,
+          audioPaused: audioRef.current?.paused,
+          audioSrc: audioRef.current?.src,
+          audioSrcChanged: audioRef.current?.src !== currentAudioSrc,
+        });
+      }, 100);
+    }, [current, isPlaying, queue]);
+    
+    // ✅ 뒤로 5초
+    const seekBackward = useCallback((seconds: number = 5) => {
+      const audio = audioRef.current;
+      if (audio && current?.audioUrl) {
+        const newTime = Math.max(0, audio.currentTime - seconds);
+        audio.currentTime = newTime;
+        setProgress(newTime);
+      }
+    }, [current]);
+    
+    // ✅ 앞으로 5초
+    const seekForward = useCallback((seconds: number = 5) => {
+      const audio = audioRef.current;
+      if (audio && current?.audioUrl) {
+        const newTime = Math.min(audio.duration || duration, audio.currentTime + seconds);
+        audio.currentTime = newTime;
+        setProgress(newTime);
+      }
+    }, [current, duration]);
+    
+    // ✅ 다음 곡
+    const nextTrack = useCallback(() => {
+      setQueue((q) => {
+        if (q.length > 0) {
+          const nextTrack = q[0];
+          setCurrent(nextTrack);
+          setProgress(0);
+          return q.slice(1);
+        }
+        return q;
+      });
+    }, []);
+    
+    // ✅ 이전 곡
+    const previousTrack = useCallback(() => {
+      setHistory((h) => {
+        if (h.length > 0) {
+          const prevTrack = h[0];
+          setCurrent(prevTrack);
+          setProgress(0);
+          // 현재 곡을 큐 앞에 추가
+          if (current) {
+            setQueue((q) => [current, ...q]);
+          }
+          return h.slice(1);
+        }
+        return h;
+      });
+    }, [current]);
+    
+    // ✅ 반복 모드 토글
+    const toggleRepeat = useCallback(() => {
+      setRepeatMode((mode) => (mode === 'off' ? 'one' : 'off'));
+    }, []);
   
     const value = useMemo<PlayerContextValue>(
       () => ({
@@ -355,6 +557,15 @@ export type PlayerContextValue = {
         // ✅ 큐 편집
         removeFromQueue,
         moveQueueItem,
+        
+        // ✅ 플레이어 컨트롤
+        shuffleQueue,
+        seekBackward,
+        seekForward,
+        nextTrack,
+        previousTrack,
+        repeatMode,
+        toggleRepeat,
       }),
       [
         current,
@@ -373,6 +584,13 @@ export type PlayerContextValue = {
         seek,
         removeFromQueue,
         moveQueueItem,
+        shuffleQueue,
+        seekBackward,
+        seekForward,
+        nextTrack,
+        previousTrack,
+        repeatMode,
+        toggleRepeat,
       ]
     );
   


### PR DESCRIPTION
- PlayerTrack 타입에 musicId 필드 추가
- NowPlayingPage에서 current.musicId가 있으면 바로 사용
- SearchAll, SearchSong에서 musicId를 PlayerTrack에 저장
- 가사 API 엔드포인트를 /api/v1/{music_id}/로 수정
- itunesId 참조 제거 및 musicId 중심으로 변경

🔗 연관된 이슈
- close #이슈번호

🔥 작업 내용


🤔 추후 작업 사항


📸 구현 결과 or 기능 GIF
(작업 내역 스크린샷)

💬리뷰 요구사항(선택)
- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면
