### PR TITLE
fix: 하단 플레이어 버튼 기능 연결 및 볼륨 조절 시 음악 멈춤 문제 수정

### DIFF
--- a/src/components/layout/Player.tsx
+++ b/src/components/layout/Player.tsx
@@ -19,7 +19,21 @@ const fmt = (s: number) => {
 export default function Player({ height = 92 }: Props) {
     const navigate = useNavigate();
 
-    const { current, isPlaying, toggle, progress, duration, seek, volume, setVolume } = usePlayer();
+    const { 
+        current, 
+        isPlaying, 
+        toggle, 
+        progress, 
+        duration, 
+        seek, 
+        volume, 
+        setVolume,
+        shuffleQueue,
+        previousTrack,
+        nextTrack,
+        toggleRepeat,
+        repeatMode,
+    } = usePlayer();
 
     const hasTrack = !!current;
     const pct = duration > 0 ? Math.min(100, (progress / duration) * 100) : 0;
@@ -113,11 +127,14 @@ export default function Player({ height = 92 }: Props) {
             {/* 셔플 */}
             <button
                 type="button"
-                className="
-                text-[#999] hover:text-[#F6F6F6]
-                transition
-                "
+                onClick={shuffleQueue}
+                disabled={!hasTrack}
+                className={[
+                    "transition",
+                    hasTrack ? "text-[#999] hover:text-[#F6F6F6]" : "text-white/30 cursor-not-allowed",
+                ].join(" ")}
                 aria-label="셔플"
+                title="재생 대기 곡들 셔플"
             >
                 <MdShuffle size={22} />
             </button>
@@ -125,11 +142,14 @@ export default function Player({ height = 92 }: Props) {
             {/* 이전 */}
             <button
                 type="button"
-                className="
-                text-[#999] hover:text-[#F6F6F6]
-                transition
-                "
+                onClick={previousTrack}
+                disabled={!hasTrack}
+                className={[
+                    "transition",
+                    hasTrack ? "text-[#999] hover:text-[#F6F6F6]" : "text-white/30 cursor-not-allowed",
+                ].join(" ")}
                 aria-label="이전 곡"
+                title="이전 곡"
             >
                 <MdSkipPrevious size={26} />
             </button>
@@ -153,11 +173,14 @@ export default function Player({ height = 92 }: Props) {
             {/* 다음 */}
             <button
                 type="button"
-                className="
-                text-[#999] hover:text-[#F6F6F6]
-                transition
-                "
+                onClick={nextTrack}
+                disabled={!hasTrack}
+                className={[
+                    "transition",
+                    hasTrack ? "text-[#999] hover:text-[#F6F6F6]" : "text-white/30 cursor-not-allowed",
+                ].join(" ")}
                 aria-label="다음 곡"
+                title="다음 곡"
             >
                 <MdSkipNext size={26} />
             </button>
@@ -165,11 +188,18 @@ export default function Player({ height = 92 }: Props) {
             {/* 반복 */}
             <button
                 type="button"
-                className="
-                text-[#999] hover:text-[#F6F6F6]
-                transition
-                "
+                onClick={toggleRepeat}
+                disabled={!hasTrack}
+                className={[
+                    "transition",
+                    hasTrack
+                        ? repeatMode === "one"
+                            ? "text-[#AFDEE2]"
+                            : "text-[#999] hover:text-[#F6F6F6]"
+                        : "text-white/30 cursor-not-allowed",
+                ].join(" ")}
                 aria-label="반복"
+                title={repeatMode === "one" ? "한 곡 반복" : "반복 끄기"}
             >
                 <MdRepeat size={22} />
             </button>

--- a/src/player/PlayerContext.tsx
+++ b/src/player/PlayerContext.tsx
@@ -121,11 +121,11 @@ export type PlayerContextValue = {
       }
     }, []);
 
-    // ✅ 오디오 요소 초기화 및 이벤트 리스너
+    // ✅ 오디오 요소 초기화 및 이벤트 리스너 (한 번만 실행)
     useEffect(() => {
       const audio = new Audio();
       audioRef.current = audio;
-      audio.volume = volume;
+      audio.volume = volume; // 초기 볼륨 설정
 
       const handleTimeUpdate = () => {
         setProgress(audio.currentTime);
@@ -241,7 +241,7 @@ export type PlayerContextValue = {
         audio.pause();
         audio.src = "";
       };
-    }, [volume]);
+    }, []); // volume dependency 제거 - 볼륨은 setVolume과 별도 useEffect에서 관리
 
     // ✅ current 변경 시 오디오 URL 로드
     useEffect(() => {
@@ -265,7 +265,7 @@ export type PlayerContextValue = {
             audioUrl: audioUrl,
           });
           audio.src = audioUrl;
-          audio.volume = volume;
+          audio.volume = volume; // 현재 볼륨 설정
           setProgress(0);
           audio.load();
         } else {
@@ -288,7 +288,15 @@ export type PlayerContextValue = {
         audio.src = "";
         setDuration(0);
       }
-    }, [current, volume]);
+    }, [current]); // volume dependency 제거 - 볼륨은 별도로 관리
+
+    // ✅ 볼륨 변경 시 오디오 볼륨만 업데이트 (오디오 재로드하지 않음)
+    useEffect(() => {
+      const audio = audioRef.current;
+      if (audio) {
+        audio.volume = volume;
+      }
+    }, [volume]);
 
     // ✅ isPlaying 변경 시 재생/일시정지
     useEffect(() => {


### PR DESCRIPTION
- 셔플, 이전/다음 곡, 반복 버튼에 onClick 핸들러 연결
- 볼륨 조절 시 오디오가 멈추는 문제 수정
- 오디오 요소 초기화 useEffect에서 volume dependency 제거
- 볼륨 변경은 별도 useEffect로 분리하여 재생 중단 방지

🔗 연관된 이슈
- close #이슈번호

🔥 작업 내용


🤔 추후 작업 사항


📸 구현 결과 or 기능 GIF
(작업 내역 스크린샷)

💬리뷰 요구사항(선택)
- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면
