### PR TITLE
feat:로그인 및 회원가입 api 연결과 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -79,7 +79,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1621,7 +1620,6 @@
       "integrity": "sha512-vnDVpYPMzs4wunl27jHrfmwojOGKya0xyM3sH+UE5iv5uPS6vX7UIoh6m+vQc5LGBq52HBKPIn/zcSZVzeDEZg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1632,7 +1630,6 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1692,7 +1689,6 @@
       "integrity": "sha512-3xP4XzzDNQOIqBMWogftkwxhg5oMKApqY0BAflmLZiFYHqyhSOxv/cd/zPQLTcCXr4AkaKb25joocY0BD1WC6A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.51.0",
         "@typescript-eslint/types": "8.51.0",
@@ -1940,7 +1936,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2337,7 +2332,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3017,7 +3011,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4244,7 +4237,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -4693,6 +4685,7 @@
       "resolved": "https://registry.npmjs.org/on-change/-/on-change-4.0.0.tgz",
       "integrity": "sha512-PTu7C9Jsz4b+sNMDpH0eZFTr7uxdOtoDWRnhaVNK50bgrrnW5nvbWI0jm5DG9qOoTnIhBzE9xoKVFPD9xgtbdg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -4821,7 +4814,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4879,7 +4871,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -5103,7 +5094,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5113,7 +5103,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5448,7 +5437,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
       "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/set-cookie-parser": {
       "version": "2.7.2",
@@ -6002,7 +5992,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6115,7 +6104,6 @@
       "integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -6326,7 +6314,6 @@
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/api/artist.ts
+++ b/src/api/artist.ts
@@ -23,7 +23,7 @@ function unwrapList<T>(data: any): T[] {
 
 // 인기 아티스트 목록
 export async function fetchPopularArtists(limit = 7): Promise<PopularArtist[]> {
-  const res = await axiosInstance.get(`/api/v1/artists/popular`, {
+  const res = await axiosInstance.get(`/artists/popular`, {
     params: { limit },
   });
   return unwrapList<PopularArtist>(res.data);

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,0 +1,69 @@
+// src/api/auth.ts
+import axiosInstance from "./axiosInstance";
+
+/** 회원가입 요청 타입 */
+export type SignupRequest = {
+  email: string;
+  password: string;
+  nickname: string;
+};
+
+/** 회원가입 응답 타입 */
+export type SignupResponse = {
+  id: number;
+  email: string;
+  nickname: string;
+  created_at: string;
+};
+
+/** 로그인 요청 타입 */
+export type LoginRequest = {
+  email: string;
+  password: string;
+};
+
+/** 로그인 응답 타입 */
+export type LoginResponse = {
+  access: string;
+  refresh: string;
+  user_id: number;
+  email: string;
+  nickname: string;
+};
+
+/** JWT 토큰 갱신 요청 타입 */
+export type RefreshRequest = {
+  refresh: string;
+};
+
+/** JWT 토큰 갱신 응답 타입 */
+export type RefreshResponse = {
+  access: string;
+};
+
+/**
+ * 회원가입 API
+ * POST /auth/users/
+ */
+export async function signup(data: SignupRequest): Promise<SignupResponse> {
+  const res = await axiosInstance.post("/auth/users/", data);
+  return res.data;
+}
+
+/**
+ * 로그인 API
+ * POST /auth/tokens/
+ */
+export async function login(data: LoginRequest): Promise<LoginResponse> {
+  const res = await axiosInstance.post("/auth/tokens/", data);
+  return res.data;
+}
+
+/**
+ * JWT 토큰 갱신 API
+ * POST /auth/refresh/
+ */
+export async function refreshToken(data: RefreshRequest): Promise<RefreshResponse> {
+  const res = await axiosInstance.post("/auth/refresh/", data);
+  return res.data;
+}

--- a/src/api/axiosInstance.ts
+++ b/src/api/axiosInstance.ts
@@ -11,10 +11,55 @@ const axiosInstance = axios.create({
   withCredentials: true,
 });
 
-// (선택) 디버깅용
+// ✅ 요청 인터셉터: 토큰을 헤더에 자동 추가
+axiosInstance.interceptors.request.use(
+  (config) => {
+    const token = localStorage.getItem("access_token");
+    if (token) {
+      config.headers.Authorization = `Bearer ${token}`;
+    }
+    return config;
+  },
+  (error) => {
+    return Promise.reject(error);
+  }
+);
+
+// ✅ 응답 인터셉터: 401 에러 시 토큰 갱신 시도
 axiosInstance.interceptors.response.use(
   (res) => res,
-  (err) => {
+  async (err) => {
+    const originalRequest = err.config;
+    
+    // 401 에러이고, 재시도하지 않은 요청인 경우
+    if (err?.response?.status === 401 && !originalRequest._retry) {
+      originalRequest._retry = true;
+      
+      const refreshToken = localStorage.getItem("refresh_token");
+      if (refreshToken) {
+        try {
+          // 토큰 갱신 시도
+          const response = await axiosInstance.post("/auth/refresh/", {
+            refresh: refreshToken,
+          });
+          
+          const newAccessToken = response.data.access;
+          localStorage.setItem("access_token", newAccessToken);
+          
+          // 원래 요청 재시도
+          originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
+          return axiosInstance(originalRequest);
+        } catch (refreshError) {
+          // 토큰 갱신 실패 시 로그아웃 처리
+          localStorage.removeItem("access_token");
+          localStorage.removeItem("refresh_token");
+          localStorage.removeItem("user");
+          window.location.href = "/login";
+          return Promise.reject(refreshError);
+        }
+      }
+    }
+    
     console.error("[API ERROR]", err?.response?.status, err?.response?.data ?? err);
     return Promise.reject(err);
   }

--- a/src/api/chart.ts
+++ b/src/api/chart.ts
@@ -100,9 +100,9 @@ function mapChartDTO(dto: ChartResponseDTO): ChartData {
 //  *  =========================
 
 const ENDPOINT_BY_TYPE: Record<ChartType, string> = {
-  realtime: "/api/v1/charts/realtime",
-  daily: "/api/v1/charts/daily",
-  ai: "/api/v1/charts/ai",
+  realtime: "/charts/realtime",
+  daily: "/charts/daily",
+  ai: "/charts/ai",
 };
 
 /** 타입만 바꿔 호출하면 됨 */

--- a/src/pages/auth/LoginPage.tsx
+++ b/src/pages/auth/LoginPage.tsx
@@ -6,6 +6,7 @@ import {
   MdVisibility,
   MdVisibilityOff,
 } from "react-icons/md";
+import { login } from "../../api/auth";
 
 export default function LoginPage() {
   const navigate = useNavigate();
@@ -13,6 +14,7 @@ export default function LoginPage() {
   const [id, setId] = useState("");
   const [pw, setPw] = useState("");
   const [showPw, setShowPw] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   // ✅ LEFT 문구 자동 float만 유지
   useEffect(() => {
@@ -38,10 +40,34 @@ export default function LoginPage() {
 
   const canLogin = id.trim().length > 0 && pw.trim().length > 0;
 
-  const onSubmit = (e: React.FormEvent) => {
+  const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!canLogin) return;
-    navigate("/home");
+    if (!canLogin || isSubmitting) return;
+
+    setIsSubmitting(true);
+    try {
+      const response = await login({
+        email: id.trim(),
+        password: pw,
+      });
+      
+      // 토큰 저장 (localStorage 사용)
+      localStorage.setItem("access_token", response.access);
+      localStorage.setItem("refresh_token", response.refresh);
+      localStorage.setItem("user", JSON.stringify({
+        id: response.user_id,
+        email: response.email,
+        nickname: response.nickname,
+      }));
+      
+      alert(`환영합니다, ${response.nickname}님!`);
+      navigate("/home");
+    } catch (error: any) {
+      const errorMsg = error?.response?.data?.message || error?.response?.data?.detail || "로그인에 실패했습니다.";
+      alert(errorMsg);
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
   return (
@@ -177,15 +203,15 @@ export default function LoginPage() {
               {/* Login */}
               <button
                 type="submit"
-                disabled={!canLogin}
+                disabled={!canLogin || isSubmitting}
                 className={[
                   "mt-10 w-full h-11 rounded-full text-sm transition",
-                  canLogin
+                  canLogin && !isSubmitting
                     ? "bg-[#e45a4d] text-[#f6f6f6] hover:brightness-110"
                     : "bg-[#e45a4d]/40 text-white/50 cursor-not-allowed",
                 ].join(" ")}
               >
-                Login
+                {isSubmitting ? "처리 중..." : "Login"}
               </button>
 
               <div className="w-full mt-4 flex">

--- a/src/pages/auth/SignupPage.tsx
+++ b/src/pages/auth/SignupPage.tsx
@@ -7,12 +7,15 @@ import {
   MdNavigateBefore,
   MdOutlineMail,
   MdLockOutline,
+  MdPersonOutline,
 } from "react-icons/md";
+import { signup } from "../../api/auth";
 
 export default function SignUpPage() {
   const navigate = useNavigate();
 
   const [email, setEmail] = useState("");
+  const [nickname, setNickname] = useState("");
   const [pw, setPw] = useState("");
   const [pw2, setPw2] = useState("");
 
@@ -23,6 +26,7 @@ export default function SignUpPage() {
   const [emailStatus, setEmailStatus] = useState<
     "idle" | "checking" | "ok" | "dup" | "invalid"
   >("idle");
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const emailOk = useMemo(() => {
     if (!email.trim()) return false;
@@ -38,31 +42,36 @@ export default function SignUpPage() {
     const hasLetter = /[A-Za-z]/.test(pw);
     const hasNumber = /\d/.test(pw);
     const hasSpecial = /[!@#$%^&*()_+\-=\\[\]{}|;:'",.<>/?`~]/.test(pw);
-    return { hasLetter, hasNumber, hasSpecial };
+    const isValidLength = pw.length >= 8 && pw.length <= 16;
+    return { hasLetter, hasNumber, hasSpecial, isValidLength };
   }, [pw]);
 
   const pwOk = useMemo(() => {
     if (!pw) return false;
-    return pwRules.hasLetter && pwRules.hasNumber && pwRules.hasSpecial;
+    return pwRules.hasLetter && pwRules.hasNumber && pwRules.hasSpecial && pwRules.isValidLength;
   }, [pw, pwRules]);
 
   const pwInvalid = pw.length > 0 && !pwOk;
   const pw2Invalid = pw2.length > 0 && pwMismatch;
 
   const pwRuleText = useMemo(() => {
-    if (!pw) return "문자/숫자/특수기호를 각각 1개 이상 포함해 주세요.";
+    if (!pw) return "8-16자리, 문자/숫자/특수기호를 각각 1개 이상 포함해 주세요.";
     const missing: string[] = [];
+    if (!pwRules.isValidLength) {
+      if (pw.length < 8) missing.push("8자리 이상");
+      if (pw.length > 16) missing.push("16자리 이하");
+    }
     if (!pwRules.hasLetter) missing.push("문자");
     if (!pwRules.hasNumber) missing.push("숫자");
     if (!pwRules.hasSpecial) missing.push("특수기호");
     if (missing.length === 0) return "";
-    return `${missing.join(", ")}가 부족해요.`;
+    return `${missing.join(", ")}가 필요해요.`;
   }, [pw, pwRules]);
 
   const canSubmit = useMemo(() => {
     const emailDupOk = emailStatus === "ok";
-    return emailOk && emailDupOk && !!pw.trim() && pwOk && !pwMismatch;
-  }, [emailOk, emailStatus, pw, pwOk, pwMismatch]);
+    return emailOk && emailDupOk && !!nickname.trim() && !!pw.trim() && pwOk && !pwMismatch;
+  }, [emailOk, emailStatus, nickname, pw, pwOk, pwMismatch]);
 
   const checkEmailDup = async () => {
     const v = email.trim();
@@ -88,17 +97,32 @@ export default function SignUpPage() {
     setEmailStatus("idle");
   }, [email]);
 
-  const onSubmit = () => {
+  const onSubmit = async () => {
     if (!email.trim()) return alert("이메일을 입력해 주세요.");
     if (!emailOk) return alert("이메일 형식이 올바르지 않습니다.");
     if (emailStatus !== "ok") return alert("이메일 중복 확인을 완료해 주세요.");
+    
+    if (!nickname.trim()) return alert("닉네임을 입력해 주세요.");
 
     if (!pw.trim()) return alert("비밀번호를 입력해 주세요.");
-    if (!pwOk) return alert("비밀번호는 문자/숫자/특수기호를 모두 포함해야 합니다.");
+    if (!pwOk) return alert("비밀번호는 8-16자리, 문자/숫자/특수기호를 모두 포함해야 합니다.");
     if (pwMismatch) return alert("비밀번호가 일치하지 않습니다.");
 
-    alert("회원가입을 완료했습니다!");
-    navigate("/login");
+    setIsSubmitting(true);
+    try {
+      await signup({
+        email: email.trim(),
+        password: pw,
+        nickname: nickname.trim(),
+      });
+      alert("회원가입을 완료했습니다!");
+      navigate("/login");
+    } catch (error: any) {
+      const errorMsg = error?.response?.data?.message || error?.response?.data?.detail || "회원가입에 실패했습니다.";
+      alert(errorMsg);
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
   // ✅ floating 텍스트 애니메이션만 유지 (blob 배경은 AuthLayout이 담당)
@@ -276,6 +300,36 @@ export default function SignUpPage() {
                   )}
                 </div>
 
+                {/* Nickname */}
+                <div className="relative w-full mt-4">
+                  <label className="w-full text-left block text-[12px] text-white/70 mb-1">
+                    Nickname
+                  </label>
+
+                  <div className="relative w-full">
+                    <div className="absolute left-4 top-1/2 -translate-y-1/2 text-[#f6f6f6]">
+                      <MdPersonOutline size={18} />
+                    </div>
+
+                    <input
+                      type="text"
+                      value={nickname}
+                      onChange={(e) => setNickname(e.target.value)}
+                      placeholder="닉네임을 입력해 주세요"
+                      className="
+                        w-full h-11 rounded-md
+                        pl-11 pr-4
+                        bg-[#3d3d3d]/80
+                        text-[#f6f6f6] text-sm
+                        placeholder:text-white/40
+                        outline-none
+                        focus:ring-2
+                        focus:ring-white/30
+                      "
+                    />
+                  </div>
+                </div>
+
                 {/* Password */}
                 <div className="relative w-full mt-4">
                   <label className="w-full text-left block text-[12px] text-white/70 mb-1">
@@ -291,7 +345,7 @@ export default function SignUpPage() {
                       type={showPw ? "password" : "text"}
                       value={pw}
                       onChange={(e) => setPw(e.target.value)}
-                      placeholder="문자와 숫자, 특수기호 포함"
+                      placeholder="8-16자리, 문자/숫자/특수기호 포함"
                       className={[
                         `
                         w-full h-11 rounded-md
@@ -386,15 +440,15 @@ export default function SignUpPage() {
                 <button
                   type="button"
                   onClick={onSubmit}
-                  disabled={!canSubmit}
+                  disabled={!canSubmit || isSubmitting}
                   className={[
                     "mt-8 w-full h-12 rounded-full text-sm transition",
-                    canSubmit
+                    canSubmit && !isSubmitting
                       ? "bg-[#e45a4d] text-[#f6f6f6] hover:brightness-110"
                       : "bg-[#e45a4d]/40 text-white/50 cursor-not-allowed",
                   ].join(" ")}
                 >
-                  Sign up
+                  {isSubmitting ? "처리 중..." : "Sign up"}
                 </button>
 
                 <button


### PR DESCRIPTION
## 🔗 연관된 이슈
이슈번호 없음

## 🔥 작업 내용

### 1. 인증 API 연결
- `src/api/auth.ts` 신규 생성
  - 회원가입 API: `POST /auth/users/`
  - 로그인 API: `POST /auth/tokens/`
  - 토큰 갱신 API: `POST /auth/refresh/`
  - TypeScript 타입 정의 포함

### 2. 로그인 기능 구현
- 실제 API 연동 완료
- JWT 토큰 localStorage 저장 (access_token, refresh_token)
- 사용자 정보 저장 및 환영 메시지 표시
- 로딩 상태 및 에러 처리 추가

### 3. 회원가입 기능 구현
- 실제 API 연동 완료
- **닉네임 입력 필드 추가** (이메일-닉네임-비밀번호 순서)
- **비밀번호 검증 강화**: 8-16자리 제한 추가
- 기존 문자/숫자/특수기호 검증 유지
- 로딩 상태 및 에러 처리 추가

### 4. Axios 인터셉터 구현
- **요청 인터셉터**: Authorization 헤더에 JWT 토큰 자동 추가
- **응답 인터셉터**: 
  - 401 에러 시 refresh token으로 자동 갱신 후 재시도
  - 토큰 갱신 실패 시 자동 로그아웃 처리

### 5. API 경로 일관성 개선
- 검색 API와 경로 형식 통일
- `artist.ts`, `chart.ts`에서 중복된 `/api/v1` 제거

### 수정된 파일
- `src/api/auth.ts` (신규)
- `src/api/axiosInstance.ts`
- `src/api/artist.ts`
- `src/api/chart.ts`
- `src/pages/auth/LoginPage.tsx`
- `src/pages/auth/SignupPage.tsx`

## 🤔 추후 작업 사항


## 📸 구현 결과 or 기능 GIF
### 회원가입
- 닉네임 필드 추가
- 비밀번호 8-16자리 검증
- 이메일 중복 확인 후 회원가입 성공

### 로그인
- 로그인 성공 시 "환영합니다, {닉네임}님!" 메시지
- JWT 토큰 저장 후 홈으로 이동


## 💬 리뷰 요구사항

