### PR TITLE
fix: image_large_square 필드를 우선 사용하도록 수정

### DIFF
--- a/src/pages/album/AlbumPage.tsx
+++ b/src/pages/album/AlbumPage.tsx
@@ -31,6 +31,7 @@ type ApiAlbumDetail = {
     album_id: number;
     album_name: string;
     album_image: string | null;
+    image_large_square: string | null; // ✅ RDS에 저장된 이미지 (우선 사용)
     artist: {
         artist_id: number;
         artist_name: string;
@@ -145,12 +146,48 @@ export default function AlbumDetailPage() {
                         ? data.created_at.slice(0, 4)
                         : "";
 
+                // ✅ image_large_square 우선 사용 (RDS에 저장된 이미지), 없으면 album_image 사용
+                const albumImage = data.image_large_square || data.album_image;
+                
                 const album: Album = {
                     id: String(data.album_id),
                     title: data.album_name,
                     year,
-                    albumImage: data.album_image,
+                    albumImage: albumImage,
                 };
+
+                // 🔍 앨범 이미지 출처 추적 로깅
+                if (albumImage) {
+                    const isExternal = albumImage.startsWith("http://") || 
+                                      albumImage.startsWith("https://") || 
+                                      albumImage.startsWith("//");
+                    const isRdsPath = albumImage.startsWith("/");
+                    
+                    console.log(`[AlbumPage] 📸 앨범 이미지 출처 추적:`, {
+                        album_id: data.album_id,
+                        album_name: data.album_name,
+                        image_large_square: data.image_large_square,
+                        album_image: data.album_image,
+                        final_image_url: albumImage,
+                        source_type: isExternal ? "외부 URL (iTunes/YouTube 등)" : isRdsPath ? "RDS 경로" : "기타",
+                        is_external: isExternal,
+                        is_rds_path: isRdsPath,
+                        using_image_large_square: !!data.image_large_square,
+                    });
+                    
+                    // "SUPER REAL ME (Sped Up) - EP" 특별 추적
+                    if (data.album_name?.includes("SUPER REAL ME")) {
+                        console.warn(`[AlbumPage] ⚠️ "SUPER REAL ME" 앨범 이미지 발견:`, {
+                            album_id: data.album_id,
+                            album_name: data.album_name,
+                            image_large_square: data.image_large_square,
+                            album_image: data.album_image,
+                            final_image_url: albumImage,
+                            source: isExternal ? "외부 API에서 가져온 것으로 추정" : "RDS 경로",
+                            using_image_large_square: !!data.image_large_square,
+                        });
+                    }
+                }
 
                 const tracks: Track[] = data.tracks.map((t) => ({
                     id: String(t.music_id),

--- a/src/pages/artist/ArtistPage.tsx
+++ b/src/pages/artist/ArtistPage.tsx
@@ -38,6 +38,7 @@ type ArtistAlbumApi = {
     title: string;
     year: string;
     album_image: string | null;
+    image_large_square: string | null; // ✅ RDS에 저장된 이미지 (우선 사용)
 };
 
     type HorizontalScrollerProps = {
@@ -276,7 +277,7 @@ export default function ArtistPage() {
                         id: a.id,
                         title: a.title,
                         year: a.year,
-                        albumImage: a.album_image,
+                        albumImage: a.image_large_square || a.album_image, // ✅ image_large_square 우선 사용
                     })),
                 });
             } catch (e: unknown) {

--- a/src/pages/search/SearchAlbum.tsx
+++ b/src/pages/search/SearchAlbum.tsx
@@ -30,6 +30,7 @@ type ArtistAlbum = {
   title: string;
   year: string;
   album_image: string | null;
+  image_large_square: string | null; // ✅ RDS에 저장된 이미지 (우선 사용)
 };
 
 const ALL_ALBUMS: Album[] = Array.from({ length: 12 }).map((_, i) => ({
@@ -109,12 +110,40 @@ export default function SearchAlbum() {
 
         console.log(`[SearchAlbum] 최종 앨범 목록: ${allAlbums.length}개 앨범`);
         allAlbums.forEach((album) => {
-          if (album.album_image) {
+          // ✅ image_large_square 우선 사용 (RDS에 저장된 이미지), 없으면 album_image 사용
+          const albumImage = album.image_large_square || album.album_image;
+          
+          if (albumImage) {
+            const isExternal = albumImage.startsWith("http://") || 
+                              albumImage.startsWith("https://") || 
+                              albumImage.startsWith("//");
+            const isRdsPath = albumImage.startsWith("/");
+            
             console.log(`[SearchAlbum] 📸 앨범 이미지:`, {
               title: album.title,
               id: album.id,
-              image_url: album.album_image,
+              image_large_square: album.image_large_square,
+              album_image: album.album_image,
+              final_image_url: albumImage,
+              source_type: isExternal ? "외부 URL (iTunes/YouTube 등)" : isRdsPath ? "RDS 경로" : "기타",
+              is_external: isExternal,
+              is_rds_path: isRdsPath,
+              using_image_large_square: !!album.image_large_square,
             });
+            
+            // "SUPER REAL ME (Sped Up) - EP" 특별 추적
+            if (album.title?.includes("SUPER REAL ME")) {
+              console.warn(`[SearchAlbum] ⚠️ "SUPER REAL ME" 앨범 이미지 발견:`, {
+                album_id: album.id,
+                album_title: album.title,
+                image_large_square: album.image_large_square,
+                album_image: album.album_image,
+                final_image_url: albumImage,
+                source: isExternal ? "외부 API에서 가져온 것으로 추정" : "RDS 경로",
+                using_image_large_square: !!album.image_large_square,
+                api_endpoint: `${API_BASE}/artists/{artistId}/albums/`,
+              });
+            }
           }
         });
 
@@ -197,7 +226,7 @@ export default function SearchAlbum() {
         title: a.title,
         artist: "", // 아티스트 정보는 별도로 관리 필요
         year: a.year,
-        image: a.album_image,
+        image: a.image_large_square || a.album_image, // ✅ image_large_square 우선 사용
       }));
     }
     if (!q) return ALL_ALBUMS;

--- a/src/pages/search/SearchAll.tsx
+++ b/src/pages/search/SearchAll.tsx
@@ -174,6 +174,7 @@ type ArtistAlbum = {
   title: string;
   year: string;
   album_image: string | null;
+  image_large_square: string | null; // ✅ RDS에 저장된 이미지 (우선 사용)
 };
 
 /* =====================
@@ -439,7 +440,7 @@ export default function SearchHome() {
       id: a.id,
       name: a.title,
       artist: "",
-      image: a.album_image,
+      image: a.image_large_square || a.album_image, // ✅ image_large_square 우선 사용
     }));
   }, [API_BASE, q, apiAlbums]);
 
@@ -535,8 +536,26 @@ export default function SearchHome() {
                             const apiSong = apiSongs.find((as) => as.id === songData.id);
                             if (apiSong?.albumId) {
                               const album = apiAlbums.find((a) => a.id === String(apiSong.albumId));
-                              songAlbumImage = album?.album_image || null;
+                              // ✅ image_large_square 우선 사용 (RDS에 저장된 이미지), 없으면 album_image 사용
+                              songAlbumImage = album?.image_large_square || album?.album_image || null;
                             }
+                          }
+                          
+                          // 🔍 "SUPER REAL ME" 앨범 이미지 추적
+                          if (songAlbumImage && (songData.albumName?.includes("SUPER REAL ME") || original?.album_name?.includes("SUPER REAL ME"))) {
+                            const isExternal = songAlbumImage.startsWith("http://") || 
+                                              songAlbumImage.startsWith("https://") || 
+                                              songAlbumImage.startsWith("//");
+                            const isRdsPath = songAlbumImage.startsWith("/");
+                            console.warn(`[SearchAll] ⚠️ "SUPER REAL ME" 앨범 이미지 발견 (검색 결과):`, {
+                              song_title: songData.title,
+                              album_name: songData.albumName || original?.album_name,
+                              image_url: songAlbumImage,
+                              source: original?.album_image ? "검색 API 응답" : "아티스트 앨범 API",
+                              source_type: isExternal ? "외부 URL (iTunes/YouTube 등)" : isRdsPath ? "RDS 경로" : "기타",
+                              is_external: isExternal,
+                              is_rds_path: isRdsPath,
+                            });
                           }
                         }
 
@@ -626,13 +645,34 @@ export default function SearchHome() {
                                           }
                                         }
 
+                                        // ✅ image_large_square 우선 사용 (RDS에 저장된 이미지), 없으면 album_image 사용
+                                        const albumFromApi = r.album_id ? apiAlbums.find((a) => a.id === String(r.album_id)) : null;
+                                        const albumImage = albumFromApi?.image_large_square || albumFromApi?.album_image || null;
+                                        
                                         const coverUrl =
                                           resolveCover(r.album_image) ||
                                           (r.album_id
-                                            ? resolveCover(
-                                                apiAlbums.find((a) => a.id === String(r.album_id))?.album_image ?? null
-                                              )
+                                            ? resolveCover(albumImage)
                                             : undefined);
+                                        
+                                        // 🔍 "SUPER REAL ME" 앨범 이미지 추적
+                                        if (coverUrl && (r.album_name?.includes("SUPER REAL ME") || r.music_name?.includes("SUPER REAL ME"))) {
+                                          const imageSource = r.album_image ? "검색 API 응답" : "아티스트 앨범 API";
+                                          const isExternal = coverUrl.startsWith("http://") || 
+                                                            coverUrl.startsWith("https://") || 
+                                                            coverUrl.startsWith("//");
+                                          const isRdsPath = coverUrl.startsWith("/");
+                                          console.warn(`[SearchAll] ⚠️ "SUPER REAL ME" 앨범 이미지 발견 (재생 트랙):`, {
+                                            song_title: r.music_name,
+                                            album_name: r.album_name,
+                                            album_id: r.album_id,
+                                            image_url: coverUrl,
+                                            source: imageSource,
+                                            source_type: isExternal ? "외부 URL (iTunes/YouTube 등)" : isRdsPath ? "RDS 경로" : "기타",
+                                            is_external: isExternal,
+                                            is_rds_path: isRdsPath,
+                                          });
+                                        }
 
                                         return {
                                           id: String(r.itunes_id),
@@ -683,6 +723,23 @@ export default function SearchHome() {
                                           ? `${API_BASE.replace("/api/v1", "")}${original.album_image}`
                                           : original.album_image)
                                       : undefined;
+                                    
+                                    // 🔍 "SUPER REAL ME" 앨범 이미지 추적
+                                    if (coverUrl && (songData.albumName?.includes("SUPER REAL ME") || original?.album_name?.includes("SUPER REAL ME"))) {
+                                      const isExternal = coverUrl.startsWith("http://") || 
+                                                        coverUrl.startsWith("https://") || 
+                                                        coverUrl.startsWith("//");
+                                      const isRdsPath = coverUrl.startsWith("/");
+                                      console.warn(`[SearchAll] ⚠️ "SUPER REAL ME" 앨범 이미지 발견 (단일 곡 재생):`, {
+                                        song_title: songData.title,
+                                        album_name: songData.albumName || original?.album_name,
+                                        image_url: coverUrl,
+                                        source: "검색 API 응답",
+                                        source_type: isExternal ? "외부 URL (iTunes/YouTube 등)" : isRdsPath ? "RDS 경로" : "기타",
+                                        is_external: isExternal,
+                                        is_rds_path: isRdsPath,
+                                      });
+                                    }
 
                                     const playerTrack: PlayerTrack = {
                                       id: songData.id,
@@ -778,10 +835,12 @@ export default function SearchHome() {
                   ) : (
                     songs.slice(0, 4).map((s) => {
                       const original = searchResults.find((r) => String(r.itunes_id) === s.id);
+                      // ✅ image_large_square 우선 사용 (RDS에 저장된 이미지), 없으면 album_image 사용
+                      const albumFromApi = original?.album_id ? apiAlbums.find((a) => a.id === String(original.album_id)) : null;
                       const albumImage =
                         original?.album_image ||
-                        (original?.album_id
-                          ? apiAlbums.find((a) => a.id === String(original.album_id))?.album_image ?? null
+                        (albumFromApi
+                          ? (albumFromApi.image_large_square || albumFromApi.album_image) ?? null
                           : null);
 
                       const resolveImage = (url: string) => {

--- a/src/pages/search/SearchSong.tsx
+++ b/src/pages/search/SearchSong.tsx
@@ -52,6 +52,7 @@ type ArtistAlbum = {
   title: string;
   year: string;
   album_image: string | null;
+  image_large_square: string | null; // ✅ RDS에 저장된 이미지 (우선 사용)
 };
 
 type ApiSearchResponse = {
@@ -420,8 +421,10 @@ export default function SearchSong() {
     
     if (apiSong?.albumId) {
       const album = albums[apiSong.albumId];
-      if (album?.album_image) {
-        const albumImage = album.album_image;
+      // ✅ image_large_square 우선 사용 (RDS에 저장된 이미지), 없으면 album_image 사용
+      const albumImage = album?.image_large_square || album?.album_image;
+      
+      if (albumImage) {
         // URL 처리 (상대 경로를 절대 경로로 변환)
         if (albumImage.startsWith("http") || albumImage.startsWith("//")) {
           coverUrl = albumImage;
@@ -429,6 +432,28 @@ export default function SearchSong() {
           coverUrl = `${API_BASE.replace("/api/v1", "")}${albumImage}`;
         } else {
           coverUrl = albumImage;
+        }
+        
+        // 🔍 "SUPER REAL ME" 앨범 이미지 추적
+        if (album.title?.includes("SUPER REAL ME") || s.album?.includes("SUPER REAL ME")) {
+          const isExternal = albumImage.startsWith("http://") || 
+                            albumImage.startsWith("https://") || 
+                            albumImage.startsWith("//");
+          const isRdsPath = albumImage.startsWith("/");
+          console.warn(`[SearchSong] ⚠️ "SUPER REAL ME" 앨범 이미지 발견:`, {
+            song_title: s.title,
+            album_title: album.title,
+            album_id: apiSong.albumId,
+            image_large_square: album.image_large_square,
+            album_image: album.album_image,
+            final_image_url: albumImage,
+            source: "아티스트 앨범 API",
+            source_type: isExternal ? "외부 URL (iTunes/YouTube 등)" : isRdsPath ? "RDS 경로" : "기타",
+            is_external: isExternal,
+            is_rds_path: isRdsPath,
+            using_image_large_square: !!album.image_large_square,
+            api_endpoint: `${API_BASE}/artists/{artistId}/albums/`,
+          });
         }
       }
     }
@@ -654,7 +679,8 @@ export default function SearchSong() {
 
                 if (apiSong?.albumId) {
                   const album = albums[apiSong.albumId];
-                  albumImage = album?.album_image || null;
+                  // ✅ image_large_square 우선 사용 (RDS에 저장된 이미지), 없으면 album_image 사용
+                  albumImage = album?.image_large_square || album?.album_image || null;
                 }
 
                 return albumImage ? (


### PR DESCRIPTION
- API 응답 타입에 image_large_square 필드 추가
- RDS에 저장된 이미지(image_large_square)를 우선 사용
- 없을 경우에만 iTunes 이미지(album_image) 사용
- 앨범 이미지 출처 추적 로깅 추가

🔗 연관된 이슈
- close #이슈번호

🔥 작업 내용


🤔 추후 작업 사항


📸 구현 결과 or 기능 GIF
(작업 내역 스크린샷)

💬리뷰 요구사항(선택)
- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면
