### PR TITLE
feat:홈 화면 차트표시,닉네임수정,개인분석코드수정

### DIFF
--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -82,14 +82,14 @@ export type StatisticsPeriod = "month" | "all";
 
 /**
  * 사용자 전체 음악 통계 조회
- * GET /api/v1/users/{user_id}/statistics/?period={period}
+ * GET /users/{user_id}/statistics/?period={period}
  */
 export async function fetchUserStatistics(
   userId: string | number,
   period: StatisticsPeriod = "month"
 ): Promise<UserStatistics> {
   const res = await axiosInstance.get<UserStatistics>(
-    `/api/v1/users/${userId}/statistics/`,
+    `/users/${userId}/statistics/`,
     { params: { period } }
   );
   return res.data;
@@ -97,14 +97,14 @@ export async function fetchUserStatistics(
 
 /**
  * 사용자 청취 시간 통계 조회
- * GET /api/v1/users/{user_id}/statistics/listening-time/?period={period}
+ * GET /users/{user_id}/statistics/listening-time/?period={period}
  */
 export async function fetchListeningTime(
   userId: string | number,
   period: StatisticsPeriod = "month"
 ): Promise<ListeningTime> {
   const res = await axiosInstance.get<ListeningTime>(
-    `/api/v1/users/${userId}/statistics/listening-time/`,
+    `/users/${userId}/statistics/listening-time/`,
     { params: { period } }
   );
   return res.data;
@@ -112,14 +112,14 @@ export async function fetchListeningTime(
 
 /**
  * 사용자 Top 장르 통계 조회
- * GET /api/v1/users/{user_id}/statistics/genres/?period={period}
+ * GET /users/{user_id}/statistics/genres/?period={period}
  */
 export async function fetchTopGenres(
   userId: string | number,
   period: StatisticsPeriod = "month"
 ): Promise<TopGenre[]> {
   const res = await axiosInstance.get<TopGenre[]>(
-    `/api/v1/users/${userId}/statistics/genres/`,
+    `/users/${userId}/statistics/genres/`,
     { params: { period } }
   );
   return Array.isArray(res.data) ? res.data : [];
@@ -127,14 +127,14 @@ export async function fetchTopGenres(
 
 /**
  * 사용자 Top 아티스트 통계 조회
- * GET /api/v1/users/{user_id}/statistics/artists/?period={period}
+ * GET /users/{user_id}/statistics/artists/?period={period}
  */
 export async function fetchTopArtists(
   userId: string | number,
   period: StatisticsPeriod = "month"
 ): Promise<TopArtist[]> {
   const res = await axiosInstance.get<TopArtist[]>(
-    `/api/v1/users/${userId}/statistics/artists/`,
+    `/users/${userId}/statistics/artists/`,
     { params: { period } }
   );
   return Array.isArray(res.data) ? res.data : [];
@@ -142,14 +142,14 @@ export async function fetchTopArtists(
 
 /**
  * 사용자 Top 태그/키워드 통계 조회
- * GET /api/v1/users/{user_id}/statistics/tags/?period={period}
+ * GET /users/{user_id}/statistics/tags/?period={period}
  */
 export async function fetchTopTags(
   userId: string | number,
   period: StatisticsPeriod = "month"
 ): Promise<TopTag[]> {
   const res = await axiosInstance.get<TopTag[]>(
-    `/api/v1/users/${userId}/statistics/tags/`,
+    `/users/${userId}/statistics/tags/`,
     { params: { period } }
   );
   return Array.isArray(res.data) ? res.data : [];
@@ -157,14 +157,14 @@ export async function fetchTopTags(
 
 /**
  * 사용자 AI 음악 생성 활동 통계 조회
- * GET /api/v1/users/{user_id}/statistics/ai-generation/?period={period}
+ * GET /users/{user_id}/statistics/ai-generation/?period={period}
  */
 export async function fetchAiGeneration(
   userId: string | number,
   period: StatisticsPeriod = "month"
 ): Promise<AiGeneration> {
   const res = await axiosInstance.get<AiGeneration>(
-    `/api/v1/users/${userId}/statistics/ai-generation/`,
+    `/users/${userId}/statistics/ai-generation/`,
     { params: { period } }
   );
   return res.data;
@@ -172,7 +172,7 @@ export async function fetchAiGeneration(
 
 /**
  * 사용자 Top 음악 차트 조회
- * GET /api/v1/users/{user_id}/statistics/tracks/?period={period}&limit={limit}
+ * GET /users/{user_id}/statistics/tracks/?period={period}&limit={limit}
  */
 export async function fetchTopTracks(
   userId: string | number,
@@ -180,7 +180,7 @@ export async function fetchTopTracks(
   limit: number = 50
 ): Promise<TopTrack[]> {
   const res = await axiosInstance.get<TopTrack[]>(
-    `/api/v1/users/${userId}/statistics/tracks/`,
+    `/users/${userId}/statistics/tracks/`,
     { params: { period, limit } }
   );
   return Array.isArray(res.data) ? res.data : [];

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,8 +1,9 @@
 import { MdOutlineNavigateNext } from "react-icons/md";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import type { Playlist } from "../../components/layout/MainLayout";
 import { createAiSong } from "../../mocks/aiSongMock";
+import { getProfile } from "../../utils/auth";
 
 const PLAYER_H = 85; // ✅ 플레이어 높이(px)
 
@@ -15,6 +16,22 @@ function Sidebar({
 }) {
   const navigate = useNavigate();
   const [prompt, setPrompt] = useState("");
+  
+  // ✅ 프로필 정보 (닉네임 + 사진) 상태로 관리
+  const [profile, setProfile] = useState(getProfile());
+  
+  // ✅ 프로필 변경 이벤트 리스너
+  useEffect(() => {
+    const handleProfileUpdate = () => {
+      setProfile(getProfile());
+    };
+    
+    window.addEventListener("profileUpdated", handleProfileUpdate);
+    
+    return () => {
+      window.removeEventListener("profileUpdated", handleProfileUpdate);
+    };
+  }, []);
 
   const CURRENT_USER_ID = "me";
   const CURRENT_USER_NAME = "나";
@@ -87,8 +104,16 @@ function Sidebar({
           <div className="mb-3 border-b border-[#464646]" />
 
           <div className="flex gap-4">
-            <div className="w-24 h-24 bg-[#777777] rounded-2xl" />
-            <span className="mt-1.5 text-base text-[#F6F6F6]">Name</span>
+            <div className="w-24 h-24 bg-[#777777] rounded-2xl overflow-hidden">
+              {profile.avatar ? (
+                <img
+                  src={profile.avatar}
+                  alt={profile.name}
+                  className="w-full h-full object-cover"
+                />
+              ) : null}
+            </div>
+            <span className="mt-1.5 text-base text-[#F6F6F6]">{profile.name}</span>
           </div>
 
           <div>

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -247,29 +247,41 @@ function HomePage() {
             try {
             setChartLoading(true);
             setChartError(null);
-    
-            const [realtime, daily, ai] = await Promise.all([
+
+            // ✅ Promise.allSettled로 변경: 일부 실패해도 성공한 것은 표시
+            const results = await Promise.allSettled([
                 fetchChart("realtime"),
                 fetchChart("daily"),
                 fetchChart("ai"),
             ]);
             if (!alive) return;
-    
+
+            const realtime = results[0].status === "fulfilled" ? results[0].value : null;
+            const daily = results[1].status === "fulfilled" ? results[1].value : null;
+            const ai = results[2].status === "fulfilled" ? results[2].value : null;
+
             // diff 계산 (realtime 기준)
-            const prev = prevRankByIdRef.current;
-            const nextDiff: Record<string, number> = {};
-            for (const item of realtime.items) {
-                const prevRank = prev[item.musicId];
-                nextDiff[item.musicId] = typeof prevRank === "number" ? prevRank - item.rank : 0;
+            if (realtime) {
+                const prev = prevRankByIdRef.current;
+                const nextDiff: Record<string, number> = {};
+                for (const item of realtime.items) {
+                    const prevRank = prev[item.musicId];
+                    nextDiff[item.musicId] = typeof prevRank === "number" ? prevRank - item.rank : 0;
+                }
+                setDiffById(nextDiff);
+
+                // 다음 비교용 스냅샷 저장
+                const nextPrev: Record<string, number> = {};
+                for (const item of realtime.items) nextPrev[item.musicId] = item.rank;
+                prevRankByIdRef.current = nextPrev;
             }
-            setDiffById(nextDiff);
-    
-            // 다음 비교용 스냅샷 저장
-            const nextPrev: Record<string, number> = {};
-            for (const item of realtime.items) nextPrev[item.musicId] = item.rank;
-            prevRankByIdRef.current = nextPrev;
-    
+
             setChartByType({ realtime, daily, ai });
+
+            // ✅ 모두 실패한 경우에만 에러 표시
+            if (!realtime && !daily && !ai) {
+                setChartError("차트 데이터를 불러올 수 없습니다.");
+            }
             } catch (e: unknown) {
             if (!alive) return;
             setChartError(getErrorMessage(e, "차트 로딩 실패"));

--- a/src/pages/profile/MyPage.tsx
+++ b/src/pages/profile/MyPage.tsx
@@ -13,6 +13,7 @@ import type { Playlist } from "../../components/layout/MainLayout";
 import { getMyAiSongs, subscribeAiSongs } from "../../mocks/aiSongMock";
 import type { AiTrack } from "../../mocks/aiSongMock";
 import { fetchUserStatistics, fetchTopTracks, type UserStatistics, type TopTrack } from "../../api/user";
+import { getCurrentUserNickname, updateCurrentUserNickname, getCurrentUserId } from "../../utils/auth";
 
 type Profile = {
     name: string;
@@ -165,8 +166,9 @@ export default function MyPage() {
             // ignore
         }
         }
+        // ✅ 로그인한 사용자의 닉네임을 기본값으로 사용
         return {
-        name: "Name",
+        name: getCurrentUserNickname(),
         avatar: "", // 기본 비워두면 회색 원 표시
         };
     });
@@ -195,19 +197,29 @@ export default function MyPage() {
     }, [editOpen]);
 
     const saveProfile = () => {
+        const newName = draft.name.trim() || getCurrentUserNickname();
         const next = {
         ...draft,
-        name: draft.name.trim() || "Name",
+        name: newName,
         };
+        
+        // ✅ localStorage의 "profile"에 저장
         setProfile(next);
         localStorage.setItem(PROFILE_KEY, JSON.stringify(next));
+        
+        // ✅ localStorage의 "user"의 nickname도 업데이트
+        updateCurrentUserNickname(newName);
+        
+        // ✅ 프로필 업데이트 이벤트 발생
+        window.dispatchEvent(new CustomEvent("profileUpdated"));
+        
         setEditOpen(false);
     };
 
     const { setTrackAndPlay } = usePlayer();
 
-    // ✅ 너희 로그인 유저로 교체
-    const CURRENT_USER_ID = "me";
+    // ✅ 로그인한 사용자 ID 가져오기
+    const CURRENT_USER_ID = getCurrentUserId() || "me";
 
     // ✅ 마이페이지 프리뷰용 AI곡
     const [myAiPreview, setMyAiPreview] = useState<AiTrack[]>([]);
@@ -839,12 +851,47 @@ export default function MyPage() {
                             const file = e.target.files?.[0];
                             if (!file) return;
 
+                            // ✅ 이미지 리사이즈 및 압축
                             const reader = new FileReader();
-                            reader.onload = () => {
+                            reader.onload = (event) => {
+                                const img = new Image();
+                                img.onload = () => {
+                                // 최대 크기 설정 (300x300)
+                                const MAX_SIZE = 300;
+                                let width = img.width;
+                                let height = img.height;
+
+                                // 비율 유지하면서 리사이즈
+                                if (width > height) {
+                                    if (width > MAX_SIZE) {
+                                    height = (height * MAX_SIZE) / width;
+                                    width = MAX_SIZE;
+                                    }
+                                } else {
+                                    if (height > MAX_SIZE) {
+                                    width = (width * MAX_SIZE) / height;
+                                    height = MAX_SIZE;
+                                    }
+                                }
+
+                                // Canvas로 리사이즈
+                                const canvas = document.createElement("canvas");
+                                canvas.width = width;
+                                canvas.height = height;
+                                const ctx = canvas.getContext("2d");
+                                if (!ctx) return;
+
+                                ctx.drawImage(img, 0, 0, width, height);
+
+                                // JPEG로 압축 (품질 0.7)
+                                const compressedDataUrl = canvas.toDataURL("image/jpeg", 0.7);
+
                                 setDraft((prev) => ({
-                                ...prev,
-                                avatar: String(reader.result || ""),
+                                    ...prev,
+                                    avatar: compressedDataUrl,
                                 }));
+                                };
+                                img.src = event.target?.result as string;
                             };
                             reader.readAsDataURL(file);
                             }}

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -16,3 +16,88 @@ export function getCurrentUserId(): number | null {
     return null;
   }
 }
+
+/**
+ * 현재 로그인한 사용자 닉네임 가져오기
+ * @returns 사용자 닉네임 (string) 또는 기본값 "Name"
+ */
+export function getCurrentUserNickname(): string {
+  try {
+    const raw = localStorage.getItem("user");
+    if (!raw) return "Name";
+    const parsed = JSON.parse(raw) as { nickname?: string };
+    return typeof parsed.nickname === "string" && parsed.nickname.trim() 
+      ? parsed.nickname 
+      : "Name";
+  } catch {
+    return "Name";
+  }
+}
+
+/**
+ * 현재 로그인한 사용자 전체 정보 가져오기
+ * @returns 사용자 정보 객체 또는 null
+ */
+export function getCurrentUser(): { id: number; email: string; nickname: string } | null {
+  try {
+    const raw = localStorage.getItem("user");
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as { id?: number; email?: string; nickname?: string };
+    if (typeof parsed.id === "number" && parsed.email && parsed.nickname) {
+      return {
+        id: parsed.id,
+        email: parsed.email,
+        nickname: parsed.nickname,
+      };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 현재 로그인한 사용자의 닉네임 업데이트
+ * @param newNickname 새로운 닉네임
+ * @returns 성공 여부
+ */
+export function updateCurrentUserNickname(newNickname: string): boolean {
+  try {
+    const raw = localStorage.getItem("user");
+    if (!raw) return false;
+    
+    const user = JSON.parse(raw) as { id?: number; email?: string; nickname?: string };
+    if (typeof user.id !== "number" || !user.email) return false;
+    
+    // 닉네임 업데이트
+    user.nickname = newNickname.trim() || "Name";
+    localStorage.setItem("user", JSON.stringify(user));
+    
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * 프로필 정보 가져오기 (프로필 사진 포함)
+ * @returns 프로필 정보 (name, avatar)
+ */
+export function getProfile(): { name: string; avatar: string } {
+  try {
+    const raw = localStorage.getItem("profile");
+    if (raw) {
+      const profile = JSON.parse(raw) as { name?: string; avatar?: string };
+      return {
+        name: profile.name || getCurrentUserNickname(),
+        avatar: profile.avatar || "",
+      };
+    }
+  } catch {
+    // ignore
+  }
+  return {
+    name: getCurrentUserNickname(),
+    avatar: "",
+  };
+}


### PR DESCRIPTION
## 🔗 연관된 이슈
- close #이슈번호

## 🔥 작업 내용

### 1. 차트 API 에러 핸들링 개선
- **문제**: HomePage에서 realtime, daily, ai 차트를 `Promise.all`로 호출 시, 하나라도 실패하면 전체 실패
- **해결**: `Promise.allSettled`로 변경하여 일부 API 실패해도 성공한 차트는 표시
- **영향**: daily, ai API가 404여도 realtime 차트는 정상 표시

### 2. 사용자 프로필 기능 구현 (localStorage 기반)
#### 닉네임 표시
- Sidebar(홈 화면 왼쪽)와 MyPage에 로그인한 사용자 닉네임 표시
- `getCurrentUserNickname()` 유틸 함수 추가

#### 프로필 편집
- 닉네임 수정 기능
- 프로필 사진 업로드 및 표시
- CustomEvent를 통한 실시간 UI 업데이트

#### 이미지 최적화
- Canvas API로 300x300px 리사이즈
- JPEG 70% 품질로 압축
- localStorage 용량 초과 문제 해결 (QuotaExceededError 방지)

### 3. User API 경로 수정
- **문제**: `/api/v1/api/v1/users/...` (중복)
- **수정**: `/api/v1/users/...` (정상)
- **추가**: 실제 user_id 사용 (`"me"` 하드코딩 → `getCurrentUserId()`)



